### PR TITLE
Add __version__

### DIFF
--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -20,6 +20,7 @@ Client implementation for using the ZAP pentesting proxy remotely.
 """
 
 __docformat__ = 'restructuredtext'
+__version__ = '0.0.9'
 
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning


### PR DESCRIPTION
per PEP8
https://www.python.org/dev/peps/pep-0008/#module-level-dunder-names

refs: https://github.com/zaproxy/zaproxy/issues/3356

`__version__` is a convention

It could also be worth holding off until this can be automated since it adds a step to tagging a release (I asked in #python on the mozilla IRC for the best way to keep the version number in one place).