### PR TITLE
Add openaapi to ZAPv2 class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,13 @@ test_requirements = (
 )
 setup(
     name="python-owasp-zap-v2.4",
-    version="0.0.11",
+    version="0.0.12",
     description="OWASP ZAP 2.6 API client",
     long_description="OWASP Zed Attack Proxy 2.6 API python client (the 2.4 package name has been kept to make it easier to upgrade)",
     author="ZAP development team",
     author_email='',
     url="https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project",
-    download_url="https://github.com/zaproxy/zap-api-python/releases/tag/0.0.11",
+    download_url="https://github.com/zaproxy/zap-api-python/releases/tag/0.0.12",
     platforms=['any'],
     license="ASL2.0",
     package_dir={

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -20,7 +20,7 @@ Client implementation for using the ZAP pentesting proxy remotely.
 """
 
 __docformat__ = 'restructuredtext'
-__version__ = '0.0.11'
+__version__ = '0.0.12'
 
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
@@ -38,6 +38,7 @@ from .forcedUser import forcedUser
 from .httpSessions import httpSessions
 from .importLogFiles import importLogFiles
 from .importurls import importurls
+from .openapi import openapi
 from .params import params
 from .pnh import pnh
 from .pscan import pscan
@@ -88,6 +89,7 @@ class ZAPv2(object):
         self.httpsessions = httpSessions(self)
         self.importLogFiles = importLogFiles(self)
         self.importurls = importurls(self)
+        self.openapi = openapi(self)
         self.params = params(self)
         self.pnh = pnh(self)
         self.pscan = pscan(self)


### PR DESCRIPTION
Change `__init__.py` to import and add the openapi to ZAPv2 class.
Bump version of the library.