### PR TITLE
validate status code returned from Zap

### DIFF
--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -60,7 +60,7 @@ class ZAPv2(object):
     base = 'http://zap/JSON/'
     base_other = 'http://zap/OTHER/'
 
-    def __init__(self, proxies=None, apikey=None):
+    def __init__(self, proxies=None, apikey=None, validate_status_code=False):
         """
         Creates an instance of the ZAP api client.
 
@@ -75,6 +75,7 @@ class ZAPv2(object):
             'https': 'http://127.0.0.1:8080'
         }
         self.__apikey = apikey
+        self.__validate_status_code=validate_status_code
 
         self.acsrf = acsrf(self)
         self.ajaxSpider = ajaxSpider(self)
@@ -123,7 +124,7 @@ class ZAPv2(object):
         # Must never leak the API key via proxied requests
         return requests.get(url, proxies=self.__proxies, verify=False, *args, **kwargs).text
 
-    def _request_api(self, url, query=None, validate_status_code=False):
+    def _request_api(self, url, query=None):
         """
         Shortcut for an API request. Will always add the apikey (if defined)
 
@@ -149,8 +150,10 @@ class ZAPv2(object):
 
         response = self.session.get(url, params=query, proxies=self.__proxies, verify=False)
 
-        if (validate_status_code and response.status_code >= 300):
-            raise Exception("Invalid status code returned from zap, which indicate failure: " + str(response.status_code))
+        if (self.__validate_status_code and response.status_code >= 300):
+            raise Exception("Invalid status code returned from zap, which indicate a failure: " 
+                                + str(response.status_code)
+                                + "response: " + response.text )
         
         return response
 

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -150,11 +150,14 @@ class ZAPv2(object):
 
         response = self.session.get(url, params=query, proxies=self.__proxies, verify=False)
 
-        if (self.__validate_status_code and response.status_code >= 300):
-            raise Exception("Invalid status code returned from zap, which indicate a failure: " 
+        if (self.__validate_status_code and response.status_code >= 300 and response.status_code < 500):
+            raise Exception("Invalid status code returned from zap, which indicate a bad request: " 
                                 + str(response.status_code)
                                 + "response: " + response.text )
-        
+        else if (self.__validate_status_code and response.status_code >= 500):
+            raise Exception("Invalid status code returned from zap, which indicate a Zap error: " 
+                                + str(response.status_code)
+                                + "response: " + response.text )
         return response
 
     def _request(self, url, get=None):

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -123,7 +123,7 @@ class ZAPv2(object):
         # Must never leak the API key via proxied requests
         return requests.get(url, proxies=self.__proxies, verify=False, *args, **kwargs).text
 
-    def _request_api(self, url, query=None):
+    def _request_api(self, url, query=None, validate_status_code=False):
         """
         Shortcut for an API request. Will always add the apikey (if defined)
 
@@ -146,7 +146,13 @@ class ZAPv2(object):
           # Add the apikey to get params for backwards compatibility
           if not query.get('apikey'):
             query['apikey'] = self.__apikey
-        return self.session.get(url, params=query, proxies=self.__proxies, verify=False)
+
+        response = self.session.get(url, params=query, proxies=self.__proxies, verify=False)
+
+        if (validate_status_code and response.status_code >= 300):
+            raise Exception("Invalid status code returned from zap, which indicate failure: " + str(response.status_code))
+        
+        return response
 
     def _request(self, url, get=None):
         """

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -151,11 +151,11 @@ class ZAPv2(object):
         response = self.session.get(url, params=query, proxies=self.__proxies, verify=False)
 
         if (self.__validate_status_code and response.status_code >= 300 and response.status_code < 500):
-            raise Exception("Invalid status code returned from zap, which indicate a bad request: " 
+            raise Exception("Non-successfull status code returned from ZAP, which indicates a bad request: " 
                                 + str(response.status_code)
                                 + "response: " + response.text )
         elif (self.__validate_status_code and response.status_code >= 500):
-            raise Exception("Invalid status code returned from zap, which indicate a Zap error: " 
+            raise Exception("Non-successfull status code returned from ZAP, which indicates a ZAP internal error: " 
                                 + str(response.status_code)
                                 + "response: " + response.text )
         return response

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -154,7 +154,7 @@ class ZAPv2(object):
             raise Exception("Invalid status code returned from zap, which indicate a bad request: " 
                                 + str(response.status_code)
                                 + "response: " + response.text )
-        else if (self.__validate_status_code and response.status_code >= 500):
+        elif (self.__validate_status_code and response.status_code >= 500):
             raise Exception("Invalid status code returned from zap, which indicate a Zap error: " 
                                 + str(response.status_code)
                                 + "response: " + response.text )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,6 +11,11 @@ def zap():
     All tests will be able to share the instance of client with the same settings."""
     yield ZAPv2(apikey='testapikey')
 
+@pytest.yield_fixture
+def zap_strict():
+    """
+    All tests will be able to share the instance of client with the same settings."""
+    yield ZAPv2(apikey='testapikey', validate_status_code=True)
 
 @pytest.yield_fixture(autouse=True)
 def client_mock():

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,6 +1,7 @@
 """
 Tests related to the main Zap Client class
 """
+import pytest
 
 TEST_PROXIES = {
     'http': 'http://127.0.0.1:8080',
@@ -25,6 +26,23 @@ def test_urlopen(zap, client_mock):
 
     assert 'X-ZAP-API-Key' not in response._request.headers
     assert 'testapikey' not in response.query
+    assert response.proxies == TEST_PROXIES
+
+
+def test_request_api_invalid_status_code(zap, client_mock):
+    """Request method should return a python object from parsed output"""
+    client_mock.register_uri('GET', 'http://zap/test', text='{"testkey": "testvalue"}', status_code=400)
+
+    try:
+        zap._request_api('http://zap/test', {'querykey': 'queryvalue'}, True)
+    except Exception:
+        pass
+    else:
+        pytest.fail("Not thrown on invalid status code")
+
+    response = client_mock.request_history[0]
+
+    assert_api_key(response)
     assert response.proxies == TEST_PROXIES
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -29,12 +29,12 @@ def test_urlopen(zap, client_mock):
     assert response.proxies == TEST_PROXIES
 
 
-def test_request_api_invalid_status_code(zap, client_mock):
-    """Request method should return a python object from parsed output"""
+def test_request_api_invalid_status_code(zap_strict, client_mock):
+    """Request method throw if invalid status code returned"""
     client_mock.register_uri('GET', 'http://zap/test', text='{"testkey": "testvalue"}', status_code=400)
 
     try:
-        zap._request_api('http://zap/test', {'querykey': 'queryvalue'}, True)
+        zap_strict._request_api('http://zap/test', {'querykey': 'queryvalue'})
     except Exception:
         pass
     else:


### PR DESCRIPTION
I discussed this in the google group - Zap python sdk does not validate the status code returned by Zap