### PR TITLE
Regenerate core APIs for ZAP version 2.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,13 @@ test_requirements = (
 )
 setup(
     name="python-owasp-zap-v2.4",
-    version="0.0.12",
+    version="0.0.13",
     description="OWASP ZAP 2.6 API client",
     long_description="OWASP Zed Attack Proxy 2.6 API python client (the 2.4 package name has been kept to make it easier to upgrade)",
     author="ZAP development team",
     author_email='',
     url="https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project",
-    download_url="https://github.com/zaproxy/zap-api-python/releases/tag/0.0.12",
+    download_url="https://github.com/zaproxy/zap-api-python/releases/tag/0.0.13",
     platforms=['any'],
     license="ASL2.0",
     package_dir={

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -20,7 +20,7 @@ Client implementation for using the ZAP pentesting proxy remotely.
 """
 
 __docformat__ = 'restructuredtext'
-__version__ = '0.0.12'
+__version__ = '0.0.13'
 
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning

--- a/src/zapv2/acsrf.py
+++ b/src/zapv2/acsrf.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/ascan.py
+++ b/src/zapv2/ascan.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,9 +40,15 @@ class ascan(object):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/view/scanProgress/', params)))
 
     def messages_ids(self, scanid):
+        """
+        Gets the IDs of the messages sent during the scan with the given ID. A message can be obtained with 'message' core view.
+        """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/view/messagesIds/', {'scanId': scanid})))
 
     def alerts_ids(self, scanid):
+        """
+        Gets the IDs of the alerts raised during the scan with the given ID. An alert can be obtained with 'alert' core view.
+        """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/view/alertsIds/', {'scanId': scanid})))
 
     @property
@@ -338,6 +344,12 @@ class ascan(object):
             params['attackStrength'] = attackstrength
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/updateScanPolicy/', params)))
 
+    def import_scan_policy(self, path, apikey=''):
+        """
+        Imports a Scan Policy using the given file system path.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/importScanPolicy/', {'path': path, 'apikey': apikey})))
+
     def add_excluded_param(self, name, type=None, url=None, apikey=''):
         """
         Adds a new parameter excluded from the scan, using the specified name. Optionally sets if the new entry applies to a specific URL (default, all URLs) and sets the ID of the type of the parameter (default, ID of any type). The type IDs can be obtained with the view excludedParamTypes. 
@@ -367,6 +379,12 @@ class ascan(object):
         Removes a parameter excluded from the scan, with the given index. The index can be obtained with the view excludedParams.
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/removeExcludedParam/', {'idx': idx, 'apikey': apikey})))
+
+    def skip_scanner(self, scanid, scannerid, apikey=''):
+        """
+        Skips the scanner using the given IDs of the scan and the scanner.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/skipScanner/', {'scanId': scanid, 'scannerId': scannerid, 'apikey': apikey})))
 
     def set_option_attack_policy(self, string, apikey=''):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionAttackPolicy/', {'String': string, 'apikey': apikey})))

--- a/src/zapv2/authentication.py
+++ b/src/zapv2/authentication.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/authorization.py
+++ b/src/zapv2/authorization.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/autoupdate.py
+++ b/src/zapv2/autoupdate.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/brk.py
+++ b/src/zapv2/brk.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/context.py
+++ b/src/zapv2/context.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/core.py
+++ b/src/zapv2/core.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,9 +33,9 @@ class core(object):
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/alert/', {'id': id})))
 
-    def alerts(self, baseurl=None, start=None, count=None):
+    def alerts(self, baseurl=None, start=None, count=None, riskid=None):
         """
-        Gets the alerts raised by ZAP, optionally filtering by URL and paginating with 'start' position and 'count' of alerts
+        Gets the alerts raised by ZAP, optionally filtering by URL or riskId, and paginating with 'start' position and 'count' of alerts
         """
         params = {}
         if baseurl is not None:
@@ -44,15 +44,28 @@ class core(object):
             params['start'] = start
         if count is not None:
             params['count'] = count
+        if riskid is not None:
+            params['riskId'] = riskid
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/alerts/', params)))
 
-    def number_of_alerts(self, baseurl=None):
+    def alerts_summary(self, baseurl=None):
         """
-        Gets the number of alerts, optionally filtering by URL
+        Gets number of alerts grouped by each risk level, optionally filtering by URL
         """
         params = {}
         if baseurl is not None:
             params['baseurl'] = baseurl
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/alertsSummary/', params)))
+
+    def number_of_alerts(self, baseurl=None, riskid=None):
+        """
+        Gets the number of alerts, optionally filtering by URL or riskId
+        """
+        params = {}
+        if baseurl is not None:
+            params['baseurl'] = baseurl
+        if riskid is not None:
+            params['riskId'] = riskid
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/numberOfAlerts/', params)))
 
     @property
@@ -69,16 +82,18 @@ class core(object):
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/sites/')))
 
-    @property
-    def urls(self):
+    def urls(self, baseurl=None):
         """
-        Gets the URLs accessed through/by ZAP
+        Gets the URLs accessed through/by ZAP, optionally filtering by (base) URL.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/urls/')))
+        params = {}
+        if baseurl is not None:
+            params['baseurl'] = baseurl
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/urls/', params)))
 
     def message(self, id):
         """
-        Gets the HTTP message with the given ID. Returns the ID, request/response headers and bodies, cookies and note.
+        Gets the HTTP message with the given ID. Returns the ID, request/response headers and bodies, cookies, note, type, RTT, and timestamp.
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/message/', {'id': id})))
 
@@ -94,6 +109,12 @@ class core(object):
         if count is not None:
             params['count'] = count
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/messages/', params)))
+
+    def messages_by_id(self, ids):
+        """
+        Gets the HTTP messages with the given IDs.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/messagesById/', {'ids': ids})))
 
     def number_of_messages(self, baseurl=None):
         """
@@ -121,7 +142,7 @@ class core(object):
     @property
     def excluded_from_proxy(self):
         """
-        Gets the regular expressions, applied to URLs, to exclude from the Proxy
+        Gets the regular expressions, applied to URLs, to exclude from the local proxies.
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/excludedFromProxy/')))
 
@@ -165,7 +186,38 @@ class core(object):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionProxyExcludedDomainsEnabled/')))
 
     @property
+    def zap_home_path(self):
+        """
+        Gets the path to ZAP's home directory.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/zapHomePath/')))
+
+    @property
+    def option_maximum_alert_instances(self):
+        """
+        Gets the maximum number of alert instances to include in a report.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionMaximumAlertInstances/')))
+
+    @property
+    def option_merge_related_alerts(self):
+        """
+        Gets whether or not related alerts will be merged in any reports generated.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionMergeRelatedAlerts/')))
+
+    @property
+    def option_alert_overrides_file_path(self):
+        """
+        Gets the path to the file with alert overrides.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionAlertOverridesFilePath/')))
+
+    @property
     def option_default_user_agent(self):
+        """
+        Gets the user agent that ZAP should use when creating HTTP messages (for example, spider messages or CONNECT requests to outgoing proxy).
+        """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionDefaultUserAgent/')))
 
     @property
@@ -269,13 +321,13 @@ class core(object):
 
     def clear_excluded_from_proxy(self, apikey=''):
         """
-        Clears the regexes of URLs excluded from the proxy.
+        Clears the regexes of URLs excluded from the local proxies.
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/clearExcludedFromProxy/', {'apikey': apikey})))
 
     def exclude_from_proxy(self, regex, apikey=''):
         """
-        Adds a regex of URLs that should be excluded from the proxy.
+        Adds a regex of URLs that should be excluded from the local proxies.
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/excludeFromProxy/', {'regex': regex, 'apikey': apikey})))
 
@@ -290,7 +342,7 @@ class core(object):
 
     def generate_root_ca(self, apikey=''):
         """
-        Generates a new Root CA certificate for the Local Proxy.
+        Generates a new Root CA certificate for the local proxies.
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/generateRootCA/', {'apikey': apikey})))
 
@@ -308,6 +360,12 @@ class core(object):
         Deletes all alerts of the current session.
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/deleteAllAlerts/', {'apikey': apikey})))
+
+    def delete_alert(self, id, apikey=''):
+        """
+        Deletes the alert with the given ID. 
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/deleteAlert/', {'id': id, 'apikey': apikey})))
 
     def run_garbage_collection(self, apikey=''):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/runGarbageCollection/', {'apikey': apikey})))
@@ -365,7 +423,31 @@ class core(object):
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/disableAllProxyChainExcludedDomains/', {'apikey': apikey})))
 
+    def set_option_maximum_alert_instances(self, numberofinstances, apikey=''):
+        """
+        Sets the maximum number of alert instances to include in a report. A value of zero is treated as unlimited.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionMaximumAlertInstances/', {'numberOfInstances': numberofinstances, 'apikey': apikey})))
+
+    def set_option_merge_related_alerts(self, enabled, apikey=''):
+        """
+        Sets whether or not related alerts will be merged in any reports generated.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionMergeRelatedAlerts/', {'enabled': enabled, 'apikey': apikey})))
+
+    def set_option_alert_overrides_file_path(self, filepath=None, apikey=''):
+        """
+        Sets (or clears, if empty) the path to the file with alert overrides.
+        """
+        params = {'apikey': apikey}
+        if filepath is not None:
+            params['filePath'] = filepath
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionAlertOverridesFilePath/', params)))
+
     def set_option_default_user_agent(self, string, apikey=''):
+        """
+        Sets the user agent that ZAP should use when creating HTTP messages (for example, spider messages or CONNECT requests to outgoing proxy).
+        """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionDefaultUserAgent/', {'String': string, 'apikey': apikey})))
 
     def set_option_proxy_chain_name(self, string, apikey=''):
@@ -408,6 +490,9 @@ class core(object):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionTimeoutInSecs/', {'Integer': integer, 'apikey': apikey})))
 
     def set_option_use_proxy_chain(self, boolean, apikey=''):
+        """
+        Sets whether or not the outgoing proxy should be used. The address/hostname of the outgoing proxy must be set to enable this option.
+        """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionUseProxyChain/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_use_proxy_chain_auth(self, boolean, apikey=''):
@@ -418,7 +503,7 @@ class core(object):
 
     def rootcert(self, apikey=''):
         """
-        Gets the Root CA certificate of the Local Proxy.
+        Gets the Root CA certificate used by the local proxies.
         """
         return (self.zap._request_other(self.zap.base_other + 'core/other/rootcert/', {'apikey': apikey}))
 
@@ -436,6 +521,12 @@ class core(object):
         Generates a report in HTML format
         """
         return (self.zap._request_other(self.zap.base_other + 'core/other/htmlreport/', {'apikey': apikey}))
+
+    def jsonreport(self, apikey=''):
+        """
+        Generates a report in JSON format
+        """
+        return (self.zap._request_other(self.zap.base_other + 'core/other/jsonreport/', {'apikey': apikey}))
 
     def mdreport(self, apikey=''):
         """
@@ -461,6 +552,12 @@ class core(object):
         if count is not None:
             params['count'] = count
         return (self.zap._request_other(self.zap.base_other + 'core/other/messagesHar/', params))
+
+    def messages_har_by_id(self, ids, apikey=''):
+        """
+        Gets the HTTP messages with the given IDs, in HAR format.
+        """
+        return (self.zap._request_other(self.zap.base_other + 'core/other/messagesHarById/', {'ids': ids, 'apikey': apikey}))
 
     def send_har_request(self, request, followredirects=None, apikey=''):
         """

--- a/src/zapv2/forcedUser.py
+++ b/src/zapv2/forcedUser.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/httpSessions.py
+++ b/src/zapv2/httpSessions.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/params.py
+++ b/src/zapv2/params.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/pscan.py
+++ b/src/zapv2/pscan.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/script.py
+++ b/src/zapv2/script.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,13 +53,15 @@ class script(object):
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/disable/', {'scriptName': scriptname, 'apikey': apikey})))
 
-    def load(self, scriptname, scripttype, scriptengine, filename, scriptdescription=None, apikey=''):
+    def load(self, scriptname, scripttype, scriptengine, filename, scriptdescription=None, charset=None, apikey=''):
         """
-        Loads a script into ZAP from the given local file, with the given name, type and engine, optionally with a description
+        Loads a script into ZAP from the given local file, with the given name, type and engine, optionally with a description, and a charset name to read the script (the charset name is required if the script is not in UTF-8, for example, in ISO-8859-1).
         """
         params = {'scriptName': scriptname, 'scriptType': scripttype, 'scriptEngine': scriptengine, 'fileName': filename, 'apikey': apikey}
         if scriptdescription is not None:
             params['scriptDescription'] = scriptdescription
+        if charset is not None:
+            params['charset'] = charset
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/load/', params)))
 
     def remove(self, scriptname, apikey=''):

--- a/src/zapv2/search.py
+++ b/src/zapv2/search.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/sessionManagement.py
+++ b/src/zapv2/sessionManagement.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/spider.py
+++ b/src/zapv2/spider.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -60,6 +60,15 @@ class spider(object):
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/allUrls/')))
 
+    def added_nodes(self, scanid=None):
+        """
+        Returns a list of the names of the nodes added to the Sites tree by the specified scan.
+        """
+        params = {}
+        if scanid is not None:
+            params['scanId'] = scanid
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/addedNodes/', params)))
+
     @property
     def domains_always_in_scope(self):
         """
@@ -101,6 +110,13 @@ class spider(object):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionMaxDuration/')))
 
     @property
+    def option_max_parse_size_bytes(self):
+        """
+        Gets the maximum size, in bytes, that a response might have to be parsed.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionMaxParseSizeBytes/')))
+
+    @property
     def option_max_scans_in_ui(self):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionMaxScansInUI/')))
 
@@ -127,6 +143,13 @@ class spider(object):
     @property
     def option_user_agent(self):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionUserAgent/')))
+
+    @property
+    def option_accept_cookies(self):
+        """
+        Gets whether or not a spider process should accept cookies while spidering.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionAcceptCookies/')))
 
     @property
     def option_handle_o_data_parameters_visited(self):
@@ -299,6 +322,12 @@ class spider(object):
     def set_option_user_agent(self, string, apikey=''):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionUserAgent/', {'String': string, 'apikey': apikey})))
 
+    def set_option_accept_cookies(self, boolean, apikey=''):
+        """
+        Sets whether or not a spider process should accept cookies while spidering.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionAcceptCookies/', {'Boolean': boolean, 'apikey': apikey})))
+
     def set_option_handle_o_data_parameters_visited(self, boolean, apikey=''):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionHandleODataParametersVisited/', {'Boolean': boolean, 'apikey': apikey})))
 
@@ -313,6 +342,12 @@ class spider(object):
 
     def set_option_max_duration(self, integer, apikey=''):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxDuration/', {'Integer': integer, 'apikey': apikey})))
+
+    def set_option_max_parse_size_bytes(self, integer, apikey=''):
+        """
+        Sets the maximum size, in bytes, that a response might have to be parsed. This allows the spider to skip big responses/files.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxParseSizeBytes/', {'Integer': integer, 'apikey': apikey})))
 
     def set_option_max_scans_in_ui(self, integer, apikey=''):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxScansInUI/', {'Integer': integer, 'apikey': apikey})))

--- a/src/zapv2/stats.py
+++ b/src/zapv2/stats.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/zapv2/users.py
+++ b/src/zapv2/users.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2016 the ZAP development team
+# Copyright 2017 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Regenerate core APIs for ZAP version 2.7.0.
Bump version to 0.0.13.