### PR TITLE
Move release notes to its own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,31 +24,3 @@ For help using OWASP ZAP API refer to:
 ## Issues
 
 To report issues related to OWASP ZAP API, bugs and enhancements requests, use the [issue tracker of the main OWASP ZAP project](https://github.com/zaproxy/zaproxy/issues).
-
-### Release to PyPi
-
-Example commands use the version `0.0.1`, it should be replaced accordingly to the version being released.
-
-Tag (and push) the new version:
-
-    git tag -s 0.0.1 -m "Version 0.0.1."
-    git push upstream 0.0.1
-
-(Checkout the tag and ensure the working copy is clean.)
-
-Build the distribution (source and wheel) files:
-
-    python setup.py sdist bdist_wheel --universal
-
-Sign the distribution files:
-
-    gpg --detach-sign -a dist/python-owasp-zap-v2.4-0.0.1.tar.gz
-    gpg --detach-sign -a dist/python_owasp_zap_v2.4-0.0.1-py2.py3-none-any.whl
-
-Upload to PyPi:
-
-     twine upload \
-         dist/python-owasp-zap-v2.4-0.0.1.tar.gz python-owasp-zap-v2.4-0.0.1.tar.gz.asc \
-         dist/python_owasp_zap_v2.4-0.0.1-py2.py3-none-any.whl python_owasp_zap_v2.4-0.0.1-py2.py3-none-any.whl.asc
-
-The user must have permissions to upload to the `python-owasp-zap-v2.4` package.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,27 @@
+### Release to PyPi
+
+Example commands use the version `0.0.1`, it should be replaced accordingly to the version being released.
+
+Tag (and push) the new version:
+
+    git tag -s 0.0.1 -m "Version 0.0.1."
+    git push upstream 0.0.1
+
+(Checkout the tag and ensure the working copy is clean.)
+
+Build the distribution (source and wheel) files:
+
+    python setup.py sdist bdist_wheel --universal
+
+Sign the distribution files:
+
+    gpg --detach-sign -a dist/python-owasp-zap-v2.4-0.0.1.tar.gz
+    gpg --detach-sign -a dist/python_owasp_zap_v2.4-0.0.1-py2.py3-none-any.whl
+
+Upload to PyPi:
+
+     twine upload \
+         dist/python-owasp-zap-v2.4-0.0.1.tar.gz python-owasp-zap-v2.4-0.0.1.tar.gz.asc \
+         dist/python_owasp_zap_v2.4-0.0.1-py2.py3-none-any.whl python_owasp_zap_v2.4-0.0.1-py2.py3-none-any.whl.asc
+
+The user must have permissions to upload to the `python-owasp-zap-v2.4` package.


### PR DESCRIPTION
Move the release notes from README to RELEASING, the release notes are
not of relevance for most users.