### PR TITLE
Add Python 3.4 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 python:
   - '2.7'
-  - '3.3'
+  - '3.4'
 install:
   - pip install -U --force setuptools pip
   - ./setup.py develop


### PR DESCRIPTION
Change .travis.yml to run the build with Python 3.4 and remove 3.3 no
longer supported by setuptools.