### PR TITLE
Update minimum Python 3 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 - Add API for WebSockets add-on, version 15.
+### Changed
+- Minimum Python 3 version is now 3.4.
 
 ### Changed
 - Allow to validate the status code returned by the ZAP API, to fail

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
     install_requires=install_dependencies,


### PR DESCRIPTION
Remove version 3.3 from setup.py, no longer supported,
Update CHANGELOG to mention the new minimum version (3.4).