### PR TITLE
Update basic-spider-scan.py

### DIFF
--- a/src/examples/basic-spider-scan.py
+++ b/src/examples/basic-spider-scan.py
@@ -49,4 +49,4 @@ print ('Active Scan completed')
 
 print ('Hosts: {}'.format(', '.join(zap.core.hosts)))
 print ('Alerts: ')
-pprint (zap.core.alerts())
+print (zap.core.alerts())


### PR DESCRIPTION
Fix syntax error
`pprint` -> `print`