### PR TITLE
Remove obsolete Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: false
 language: python
 python:
   - '2.7'


### PR DESCRIPTION
Remove the `sudo` configuration, the builds run now always in the same
(new) infrastructure regardless of the configuration.