### PR TITLE
Add newer Python versions to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
+dist: xenial
 sudo: false
 language: python
 python:
   - '2.7'
-  - '3.4'
+  - '3.6'
+  - '3.7'
 install:
   - pip install -U --force setuptools pip
   - ./setup.py develop


### PR DESCRIPTION
Test also with Python 3.6 and 3.7 to ensure the API client still plays
nice with those versions.
Use Xenial dist which includes 3.7.
Remove 3.4, no longer supported.