### PR TITLE
Update Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/pypi/v/python-owasp-zap-v2.4.svg)](https://pypi.python.org/pypi/python-owasp-zap-v2.4)
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
-[![Build Status](https://api.travis-ci.org/zaproxy/zap-api-python.svg?branch=master)](https://travis-ci.org/zaproxy/zap-api-python)
+[![Build Status](https://api.travis-ci.com/zaproxy/zap-api-python.svg?branch=master)](https://travis-ci.com/zaproxy/zap-api-python)
 
 The Python implementation to access the [OWASP ZAP API](https://github.com/zaproxy/zaproxy/wiki/ApiDetails). For more information
 about OWASP ZAP consult the (main) [OWASP ZAP project](https://github.com/zaproxy/zaproxy/).


### PR DESCRIPTION
Use `travis-ci.com`, the project was migrated there.