### PR TITLE
Add more core APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-
+### Added
+- Core APIs from ZAP version 2.8.0.
 
 ## [0.0.15] - 2019-06-14
 ### Added

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -40,12 +40,14 @@ from .forcedUser import forcedUser
 from .httpSessions import httpSessions
 from .importLogFiles import importLogFiles
 from .importurls import importurls
+from .localProxies import localProxies
 from .openapi import openapi
 from .params import params
 from .pnh import pnh
 from .pscan import pscan
 from .replacer import replacer
 from .reveal import reveal
+from .ruleConfig import ruleConfig
 from .script import script
 from .search import search
 from .selenium import selenium
@@ -96,12 +98,14 @@ class ZAPv2(object):
         self.httpsessions = httpSessions(self)
         self.importLogFiles = importLogFiles(self)
         self.importurls = importurls(self)
+        self.localProxies = localProxies(self)
         self.openapi = openapi(self)
         self.params = params(self)
         self.pnh = pnh(self)
         self.pscan = pscan(self)
         self.replacer = replacer(self)
         self.reveal = reveal(self)
+        self.ruleConfig = ruleConfig(self)
         self.script = script(self)
         self.search = search(self)
         self.selenium = selenium(self)

--- a/src/zapv2/localProxies.py
+++ b/src/zapv2/localProxies.py
@@ -1,0 +1,54 @@
+# Zed Attack Proxy (ZAP) and its related class files.
+#
+# ZAP is an HTTP/HTTPS proxy for assessing web application security.
+#
+# Copyright 2019 the ZAP development team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This file was automatically generated.
+"""
+
+import six
+
+
+class localProxies(object):
+
+    def __init__(self, zap):
+        self.zap = zap
+
+    @property
+    def additional_proxies(self):
+        """
+        Gets all of the additional proxies that have been configured.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'localProxies/view/additionalProxies/')))
+
+    def add_additional_proxy(self, address, port, behindnat=None, alwaysdecodezip=None, removeunsupportedencodings=None, apikey=''):
+        """
+        Adds an new proxy using the details supplied.
+        """
+        params = {'address': address, 'port': port, 'apikey': apikey}
+        if behindnat is not None:
+            params['behindNat'] = behindnat
+        if alwaysdecodezip is not None:
+            params['alwaysDecodeZip'] = alwaysdecodezip
+        if removeunsupportedencodings is not None:
+            params['removeUnsupportedEncodings'] = removeunsupportedencodings
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'localProxies/action/addAdditionalProxy/', params)))
+
+    def remove_additional_proxy(self, address, port, apikey=''):
+        """
+        Removes the additional proxy with the specified address and port.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'localProxies/action/removeAdditionalProxy/', {'address': address, 'port': port, 'apikey': apikey})))

--- a/src/zapv2/ruleConfig.py
+++ b/src/zapv2/ruleConfig.py
@@ -1,0 +1,62 @@
+# Zed Attack Proxy (ZAP) and its related class files.
+#
+# ZAP is an HTTP/HTTPS proxy for assessing web application security.
+#
+# Copyright 2019 the ZAP development team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This file was automatically generated.
+"""
+
+import six
+
+
+class ruleConfig(object):
+
+    def __init__(self, zap):
+        self.zap = zap
+
+    def rule_config_value(self, key):
+        """
+        Show the specified rule configuration
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ruleConfig/view/ruleConfigValue/', {'key': key})))
+
+    @property
+    def all_rule_configs(self):
+        """
+        Show all of the rule configurations
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ruleConfig/view/allRuleConfigs/')))
+
+    def reset_rule_config_value(self, key, apikey=''):
+        """
+        Reset the specified rule configuration, which must already exist
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ruleConfig/action/resetRuleConfigValue/', {'key': key, 'apikey': apikey})))
+
+    def reset_all_rule_config_values(self, apikey=''):
+        """
+        Reset all of the rule configurations
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ruleConfig/action/resetAllRuleConfigValues/', {'apikey': apikey})))
+
+    def set_rule_config_value(self, key, value=None, apikey=''):
+        """
+        Set the specified rule configuration, which must already exist
+        """
+        params = {'key': key, 'apikey': apikey}
+        if value is not None:
+            params['value'] = value
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ruleConfig/action/setRuleConfigValue/', params)))


### PR DESCRIPTION
Add core APIs to manage local proxies and rule configs, already present
in 2.8.0.