### PR TITLE
Fix for 'Secure Only' Api Setting

### DIFF
--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -89,7 +89,7 @@ class ZAPv2(object):
         
         if secure_only:
             self.base = 'https://zap/JSON/'
-            self.base_other = 'https://zap/OTHER/"
+            self.base_other = 'https://zap/OTHER/'
 
         self.accessControl = accessControl(self)
         self.acsrf = acsrf(self)

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -70,7 +70,7 @@ class ZAPv2(object):
     base = 'http://zap/JSON/'
     base_other = 'http://zap/OTHER/'
 
-    def __init__(self, proxies=None, apikey=None, validate_status_code=False):
+    def __init__(self, proxies=None, apikey=None, validate_status_code=False, secure_only=False):
         """
         Creates an instance of the ZAP api client.
 
@@ -86,6 +86,10 @@ class ZAPv2(object):
         }
         self.__apikey = apikey
         self.__validate_status_code=validate_status_code
+        
+        if secure_only:
+            self.base = 'https://zap/JSON/'
+            self.base_other = 'https://zap/OTHER/"
 
         self.accessControl = accessControl(self)
         self.acsrf = acsrf(self)
@@ -151,7 +155,7 @@ class ZAPv2(object):
         :Parameters:
            - `url`: the url to GET at.
         """
-        if not url.startswith('http://zap/'):
+        if not (url.startswith('http://zap/') or url.startswith('https://zap')):
           # Only allow requests to the API so that we never leak the apikey
           raise ValueError('A non ZAP API url was specified ' + url)
 


### PR DESCRIPTION
Issue description: Requests that were being issued when the ZAP API option "Secure Only" was set were resulting in invalid requests. The proxy would attempt to communicate over the 'base' url, which is hardcoded to http://zap/. 

Additionally, there is a check to ensure our API token isn't leaked, and it checks startswith('http://zap'). 

Proposed solution: This pull request is my quick fix. It adds a secure_only flag to the class instantiation, defaulting to False. When passed as True, it will update the base and base_other variables to be https://zap.... The check for API token leakage is updated to check startswith http or startswith https. 