### PR TITLE
Remove Python 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-
+### Changed
+ - Python 2.7 is no longer supported.
 
 ## [0.0.18] - 2020-12-18
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Version](https://img.shields.io/pypi/v/python-owasp-zap-v2.4.svg)](https://pypi.python.org/pypi/python-owasp-zap-v2.4)
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
-[![Build Status](https://api.travis-ci.com/zaproxy/zap-api-python.svg?branch=master)](https://travis-ci.com/zaproxy/zap-api-python)
 
 The Python implementation to access the [OWASP ZAP API](https://www.zaproxy.org/docs/api/). For more information
 about OWASP ZAP consult the (main) [OWASP ZAP project](https://github.com/zaproxy/zaproxy/).

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,6 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Do not test with Python 2.7, already in end of life.
Remove Travis CI reference in README, missed in previous change.