### PR TITLE
Add/update APIs of add-ons and core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [0.0.21] - 2022-10-28
+### Added
+- Add the API of the following add-on:
+  - Import/Export version 0.3.0.
+
+### Changed
+- Update core APIs for 2.12.
+- Update the APIs of the following add-ons:
+  - Network version 0.3.0;
+  - Replacer version 11;
+  - Selenium version 15.11.0;
+  - Spider version 0.1.0.
+
+## [0.0.20] - 2022-02-09
 ### Changed
 - Update core APIs for 2.11.1
 - Update all add-on APIs
@@ -112,7 +125,8 @@ ensure it's automatically sent in all API requests.
 ### Changed
 - Moved from the main `zaproxy` repository.
 
-[Unreleased]: https://github.com/zaproxy/zap-api-python/compare/0.0.19...HEAD
+[0.0.21]: https://github.com/zaproxy/zap-api-python/compare/0.0.20...0.0.21
+[0.0.20]: https://github.com/zaproxy/zap-api-python/compare/0.0.19...0.0.20
 [0.0.19]: https://github.com/zaproxy/zap-api-python/compare/0.0.18...0.0.19
 [0.0.18]: https://github.com/zaproxy/zap-api-python/compare/0.0.17...0.0.18
 [0.0.17]: https://github.com/zaproxy/zap-api-python/compare/0.0.16...0.0.17

--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,13 @@ test_requirements = (
 )
 setup(
     name="python-owasp-zap-v2.4",
-    version="0.0.20",
-    description="OWASP ZAP 2.11 API client",
-    long_description="OWASP Zed Attack Proxy 2.11 API Python client (the 2.4 package name has been kept to make it easier to upgrade)",
+    version="0.0.21",
+    description="OWASP ZAP 2.12 API client",
+    long_description="OWASP Zed Attack Proxy 2.12 API Python client (the 2.4 package name has been kept to make it easier to upgrade)",
     author="ZAP development team",
     author_email='',
     url="https://www.zaproxy.org/",
-    download_url="https://github.com/zaproxy/zap-api-python/releases/tag/0.0.20",
+    download_url="https://github.com/zaproxy/zap-api-python/releases/tag/0.0.21",
     platforms=['any'],
     license="ASL2.0",
     package_dir={
@@ -47,9 +47,9 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     install_requires=install_dependencies,
     tests_require=test_requirements,

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -20,7 +20,7 @@ Client implementation for using the ZAP pentesting proxy remotely.
 """
 
 __docformat__ = 'restructuredtext'
-__version__ = '0.0.20'
+__version__ = '0.0.21'
 
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
@@ -38,6 +38,7 @@ from .autoupdate import autoupdate
 from .brk import brk
 from .context import context
 from .core import core
+from .exim import exim
 from .exportreport import exportreport
 from .forcedUser import forcedUser
 from .graphql import graphql
@@ -105,6 +106,7 @@ class ZAPv2(object):
         self.brk = brk(self)
         self.context = context(self)
         self.core = core(self)
+        self.exim = exim(self)
         self.exportreport = exportreport(self)
         self.forcedUser = forcedUser(self)
         self.graphql = graphql(self)

--- a/src/zapv2/acsrf.py
+++ b/src/zapv2/acsrf.py
@@ -59,8 +59,11 @@ class acsrf(object):
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'acsrf/action/setOptionPartialMatchingEnabled/', {'Boolean': boolean, 'apikey': apikey})))
 
-    def gen_form(self, hrefid, apikey=''):
+    def gen_form(self, hrefid, actionurl=None, apikey=''):
         """
         Generate a form for testing lack of anti-CSRF tokens - typically invoked via ZAP
         """
-        return (self.zap._request_other(self.zap.base_other + 'acsrf/other/genForm/', {'hrefId': hrefid, 'apikey': apikey}))
+        params = {'hrefId': hrefid, 'apikey': apikey}
+        if actionurl is not None:
+            params['actionUrl'] = actionurl
+        return (self.zap._request_other(self.zap.base_other + 'acsrf/other/genForm/', params))

--- a/src/zapv2/ascan.py
+++ b/src/zapv2/ascan.py
@@ -80,7 +80,7 @@ class ascan(object):
 
     def scanners(self, scanpolicyname=None, policyid=None):
         """
-        Gets the scanners, optionally, of the given scan policy and/or scanner policy/category ID.
+        Gets the scan rules, optionally, of the given scan policy or scanner policy/category ID.
         """
         params = {}
         if scanpolicyname is not None:
@@ -284,7 +284,7 @@ class ascan(object):
 
     def scan(self, url=None, recurse=None, inscopeonly=None, scanpolicyname=None, method=None, postdata=None, contextid=None, apikey=''):
         """
-        Runs the active scanner against the given URL and/or Context. Optionally, the 'recurse' parameter can be used to scan URLs under the given URL, the parameter 'inScopeOnly' can be used to constrain the scan to URLs that are in scope (ignored if a Context is specified), the parameter 'scanPolicyName' allows to specify the scan policy (if none is given it uses the default scan policy), the parameters 'method' and 'postData' allow to select a given request in conjunction with the given URL.
+        Runs the active scanner against the given URL or Context. Optionally, the 'recurse' parameter can be used to scan URLs under the given URL, the parameter 'inScopeOnly' can be used to constrain the scan to URLs that are in scope (ignored if a Context is specified), the parameter 'scanPolicyName' allows to specify the scan policy (if none is given it uses the default scan policy), the parameters 'method' and 'postData' allow to select a given request in conjunction with the given URL.
         """
         params = {'apikey': apikey}
         if url is not None:
@@ -386,7 +386,7 @@ class ascan(object):
 
     def enable_all_scanners(self, scanpolicyname=None, apikey=''):
         """
-        Enables all scanners of the scan policy with the given name, or the default if none given.
+        Enables all scan rules of the scan policy with the given name, or the default if none given.
         """
         params = {'apikey': apikey}
         if scanpolicyname is not None:
@@ -395,7 +395,7 @@ class ascan(object):
 
     def disable_all_scanners(self, scanpolicyname=None, apikey=''):
         """
-        Disables all scanners of the scan policy with the given name, or the default if none given.
+        Disables all scan rules of the scan policy with the given name, or the default if none given.
         """
         params = {'apikey': apikey}
         if scanpolicyname is not None:
@@ -404,7 +404,7 @@ class ascan(object):
 
     def enable_scanners(self, ids, scanpolicyname=None, apikey=''):
         """
-        Enables the scanners with the given IDs (comma separated list of IDs) of the scan policy with the given name, or the default if none given.
+        Enables the scan rules with the given IDs (comma separated list of IDs) of the scan policy with the given name, or the default if none given.
         """
         params = {'ids': ids, 'apikey': apikey}
         if scanpolicyname is not None:
@@ -413,7 +413,7 @@ class ascan(object):
 
     def disable_scanners(self, ids, scanpolicyname=None, apikey=''):
         """
-        Disables the scanners with the given IDs (comma separated list of IDs) of the scan policy with the given name, or the default if none given.
+        Disables the scan rules with the given IDs (comma separated list of IDs) of the scan policy with the given name, or the default if none given.
         """
         params = {'ids': ids, 'apikey': apikey}
         if scanpolicyname is not None:

--- a/src/zapv2/core.py
+++ b/src/zapv2/core.py
@@ -247,6 +247,13 @@ class core(object):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionHttpState/')))
 
     @property
+    def option_http_state_enabled(self):
+        """
+        
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionHttpStateEnabled/')))
+
+    @property
     def option_proxy_chain_name(self):
         """
         
@@ -268,6 +275,13 @@ class core(object):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionProxyChainPort/')))
 
     @property
+    def option_proxy_chain_prompt(self):
+        """
+        
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionProxyChainPrompt/')))
+
+    @property
     def option_proxy_chain_realm(self):
         """
         
@@ -282,32 +296,18 @@ class core(object):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionProxyChainUserName/')))
 
     @property
-    def option_timeout_in_secs(self):
-        """
-        Gets the connection time out (in seconds).
-        """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionTimeoutInSecs/')))
-
-    @property
-    def option_http_state_enabled(self):
-        """
-        
-        """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionHttpStateEnabled/')))
-
-    @property
-    def option_proxy_chain_prompt(self):
-        """
-        
-        """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionProxyChainPrompt/')))
-
-    @property
     def option_single_cookie_request_header(self):
         """
         
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionSingleCookieRequestHeader/')))
+
+    @property
+    def option_timeout_in_secs(self):
+        """
+        Gets the connection time out (in seconds).
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/view/optionTimeoutInSecs/')))
 
     @property
     def option_use_proxy_chain(self):
@@ -534,6 +534,18 @@ class core(object):
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionDefaultUserAgent/', {'String': string, 'apikey': apikey})))
 
+    def set_option_dns_ttl_successful_queries(self, integer, apikey=''):
+        """
+        Sets the TTL (in seconds) of successful DNS queries (applies after ZAP restart).
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionDnsTtlSuccessfulQueries/', {'Integer': integer, 'apikey': apikey})))
+
+    def set_option_http_state_enabled(self, boolean, apikey=''):
+        """
+        
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionHttpStateEnabled/', {'Boolean': boolean, 'apikey': apikey})))
+
     def set_option_proxy_chain_name(self, string, apikey=''):
         """
         
@@ -545,6 +557,18 @@ class core(object):
         
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainPassword/', {'String': string, 'apikey': apikey})))
+
+    def set_option_proxy_chain_port(self, integer, apikey=''):
+        """
+        
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainPort/', {'Integer': integer, 'apikey': apikey})))
+
+    def set_option_proxy_chain_prompt(self, boolean, apikey=''):
+        """
+        
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainPrompt/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_proxy_chain_realm(self, string, apikey=''):
         """
@@ -563,30 +587,6 @@ class core(object):
         
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainUserName/', {'String': string, 'apikey': apikey})))
-
-    def set_option_dns_ttl_successful_queries(self, integer, apikey=''):
-        """
-        Sets the TTL (in seconds) of successful DNS queries (applies after ZAP restart).
-        """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionDnsTtlSuccessfulQueries/', {'Integer': integer, 'apikey': apikey})))
-
-    def set_option_http_state_enabled(self, boolean, apikey=''):
-        """
-        
-        """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionHttpStateEnabled/', {'Boolean': boolean, 'apikey': apikey})))
-
-    def set_option_proxy_chain_port(self, integer, apikey=''):
-        """
-        
-        """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainPort/', {'Integer': integer, 'apikey': apikey})))
-
-    def set_option_proxy_chain_prompt(self, boolean, apikey=''):
-        """
-        
-        """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainPrompt/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_single_cookie_request_header(self, boolean, apikey=''):
         """

--- a/src/zapv2/exim.py
+++ b/src/zapv2/exim.py
@@ -1,0 +1,87 @@
+# Zed Attack Proxy (ZAP) and its related class files.
+#
+# ZAP is an HTTP/HTTPS proxy for assessing web application security.
+#
+# Copyright 2022 the ZAP development team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This file was automatically generated.
+"""
+
+import six
+
+
+class exim(object):
+
+    def __init__(self, zap):
+        self.zap = zap
+
+    def import_har(self, filepath, apikey=''):
+        """
+        Imports a HAR file.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'exim/action/importHar/', {'filePath': filepath, 'apikey': apikey})))
+
+    def import_urls(self, filepath, apikey=''):
+        """
+        Imports URLs (one per line) from the file with the given file system path.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'exim/action/importUrls/', {'filePath': filepath, 'apikey': apikey})))
+
+    def import_zap_logs(self, filepath, apikey=''):
+        """
+        Imports previously exported ZAP messages from the file with the given file system path.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'exim/action/importZapLogs/', {'filePath': filepath, 'apikey': apikey})))
+
+    def import_modsec_2_logs(self, filepath, apikey=''):
+        """
+        Imports ModSecurity2 logs from the file with the given file system path.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'exim/action/importModsec2Logs/', {'filePath': filepath, 'apikey': apikey})))
+
+    def export_har(self, baseurl=None, start=None, count=None, apikey=''):
+        """
+        Gets the HTTP messages sent through/by ZAP, in HAR format, optionally filtered by URL and paginated with 'start' position and 'count' of messages
+        This component is optional and therefore the API will only work if it is installed
+        """
+        params = {'apikey': apikey}
+        if baseurl is not None:
+            params['baseurl'] = baseurl
+        if start is not None:
+            params['start'] = start
+        if count is not None:
+            params['count'] = count
+        return (self.zap._request_other(self.zap.base_other + 'exim/other/exportHar/', params))
+
+    def export_har_by_id(self, ids, apikey=''):
+        """
+        Gets the HTTP messages with the given IDs, in HAR format.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return (self.zap._request_other(self.zap.base_other + 'exim/other/exportHarById/', {'ids': ids, 'apikey': apikey}))
+
+    def send_har_request(self, request, followredirects=None, apikey=''):
+        """
+        Sends the first HAR request entry, optionally following redirections. Returns, in HAR format, the request sent and response received and followed redirections, if any. The Mode is enforced when sending the request (and following redirections), custom manual requests are not allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        params = {'request': request, 'apikey': apikey}
+        if followredirects is not None:
+            params['followRedirects'] = followredirects
+        return (self.zap._request_other(self.zap.base_other + 'exim/other/sendHarRequest/', params))

--- a/src/zapv2/network.py
+++ b/src/zapv2/network.py
@@ -67,6 +67,86 @@ class network(object):
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/view/getPassThroughs/')))
 
+    @property
+    def get_connection_timeout(self):
+        """
+        Gets the connection timeout, in seconds.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/view/getConnectionTimeout/')))
+
+    @property
+    def get_default_user_agent(self):
+        """
+        Gets the default user-agent.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/view/getDefaultUserAgent/')))
+
+    @property
+    def get_dns_ttl_successful_queries(self):
+        """
+        Gets the TTL (in seconds) of successful DNS queries.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/view/getDnsTtlSuccessfulQueries/')))
+
+    @property
+    def get_http_proxy(self):
+        """
+        Gets the HTTP proxy.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/view/getHttpProxy/')))
+
+    @property
+    def get_http_proxy_exclusions(self):
+        """
+        Gets the HTTP proxy exclusions.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/view/getHttpProxyExclusions/')))
+
+    @property
+    def get_socks_proxy(self):
+        """
+        Gets the SOCKS proxy.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/view/getSocksProxy/')))
+
+    @property
+    def is_http_proxy_auth_enabled(self):
+        """
+        Tells whether or not the HTTP proxy authentication is enabled.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/view/isHttpProxyAuthEnabled/')))
+
+    @property
+    def is_http_proxy_enabled(self):
+        """
+        Tells whether or not the HTTP proxy is enabled.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/view/isHttpProxyEnabled/')))
+
+    @property
+    def is_socks_proxy_enabled(self):
+        """
+        Tells whether or not the SOCKS proxy is enabled.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/view/isSocksProxyEnabled/')))
+
+    @property
+    def is_use_global_http_state(self):
+        """
+        Tells whether or not to use global HTTP state.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/view/isUseGlobalHttpState/')))
+
     def generate_root_ca_cert(self, apikey=''):
         """
         Generates a new Root CA certificate, used to issue server certificates.
@@ -167,6 +247,140 @@ class network(object):
         This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setPassThroughEnabled/', {'authority': authority, 'enabled': enabled, 'apikey': apikey})))
+
+    def set_connection_timeout(self, timeout, apikey=''):
+        """
+        Sets the timeout, for reads and connects.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setConnectionTimeout/', {'timeout': timeout, 'apikey': apikey})))
+
+    def set_default_user_agent(self, useragent, apikey=''):
+        """
+        Sets the default user-agent.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setDefaultUserAgent/', {'userAgent': useragent, 'apikey': apikey})))
+
+    def set_dns_ttl_successful_queries(self, ttl, apikey=''):
+        """
+        Sets the TTL of successful DNS queries.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setDnsTtlSuccessfulQueries/', {'ttl': ttl, 'apikey': apikey})))
+
+    def add_http_proxy_exclusion(self, host, enabled=None, apikey=''):
+        """
+        Adds a host to be excluded from the HTTP proxy.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        params = {'host': host, 'apikey': apikey}
+        if enabled is not None:
+            params['enabled'] = enabled
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/addHttpProxyExclusion/', params)))
+
+    def remove_http_proxy_exclusion(self, host, apikey=''):
+        """
+        Removes a HTTP proxy exclusion.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/removeHttpProxyExclusion/', {'host': host, 'apikey': apikey})))
+
+    def set_http_proxy(self, host, port, realm=None, username=None, password=None, apikey=''):
+        """
+        Sets the HTTP proxy configuration.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        params = {'host': host, 'port': port, 'apikey': apikey}
+        if realm is not None:
+            params['realm'] = realm
+        if username is not None:
+            params['username'] = username
+        if password is not None:
+            params['password'] = password
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setHttpProxy/', params)))
+
+    def set_http_proxy_auth_enabled(self, enabled, apikey=''):
+        """
+        Sets whether or not the HTTP proxy authentication is enabled.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setHttpProxyAuthEnabled/', {'enabled': enabled, 'apikey': apikey})))
+
+    def set_http_proxy_enabled(self, enabled, apikey=''):
+        """
+        Sets whether or not the HTTP proxy is enabled.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setHttpProxyEnabled/', {'enabled': enabled, 'apikey': apikey})))
+
+    def set_http_proxy_exclusion_enabled(self, host, enabled, apikey=''):
+        """
+        Sets whether or not a HTTP proxy exclusion is enabled.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setHttpProxyExclusionEnabled/', {'host': host, 'enabled': enabled, 'apikey': apikey})))
+
+    def set_socks_proxy(self, host, port, version=None, usedns=None, username=None, password=None, apikey=''):
+        """
+        Sets the SOCKS proxy configuration.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        params = {'host': host, 'port': port, 'apikey': apikey}
+        if version is not None:
+            params['version'] = version
+        if usedns is not None:
+            params['useDns'] = usedns
+        if username is not None:
+            params['username'] = username
+        if password is not None:
+            params['password'] = password
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setSocksProxy/', params)))
+
+    def set_socks_proxy_enabled(self, enabled, apikey=''):
+        """
+        Sets whether or not the SOCKS proxy is enabled.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setSocksProxyEnabled/', {'enabled': enabled, 'apikey': apikey})))
+
+    def set_use_global_http_state(self, use, apikey=''):
+        """
+        Sets whether or not to use the global HTTP state.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setUseGlobalHttpState/', {'use': use, 'apikey': apikey})))
+
+    def add_pkcs_12_client_certificate(self, filepath, password, index=None, apikey=''):
+        """
+        Adds a client certificate contained in a PKCS#12 file, the certificate is automatically set as active and used.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        params = {'filePath': filepath, 'password': password, 'apikey': apikey}
+        if index is not None:
+            params['index'] = index
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/addPkcs12ClientCertificate/', params)))
+
+    def set_use_client_certificate(self, use, apikey=''):
+        """
+        Sets whether or not to use the active client certificate.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setUseClientCertificate/', {'use': use, 'apikey': apikey})))
+
+    def proxy_pac(self, apikey=''):
+        """
+        Provides a PAC file, proxying through the main proxy.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return (self.zap._request_other(self.zap.base_other + 'network/other/proxy.pac/', {'apikey': apikey}))
+
+    def set_proxy(self, proxy, apikey=''):
+        """
+        Sets the HTTP proxy configuration.
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return (self.zap._request_other(self.zap.base_other + 'network/other/setProxy/', {'proxy': proxy, 'apikey': apikey}))
 
     def root_ca_cert(self, apikey=''):
         """

--- a/src/zapv2/pscan.py
+++ b/src/zapv2/pscan.py
@@ -44,7 +44,7 @@ class pscan(object):
     @property
     def scanners(self):
         """
-        Lists all passive scanners with its ID, name, enabled state and alert threshold.
+        Lists all passive scan rules with their ID, name, enabled state, and alert threshold.
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/view/scanners/')))
 
@@ -54,6 +54,13 @@ class pscan(object):
         Show information about the passive scan rule currently being run (if any).
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/view/currentRule/')))
+
+    @property
+    def current_tasks(self):
+        """
+        Show information about the passive scan tasks currently being run (if any).
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/view/currentTasks/')))
 
     @property
     def max_alerts_per_rule(self):
@@ -76,25 +83,25 @@ class pscan(object):
 
     def enable_all_scanners(self, apikey=''):
         """
-        Enables all passive scanners
+        Enables all passive scan rules
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/enableAllScanners/', {'apikey': apikey})))
 
     def disable_all_scanners(self, apikey=''):
         """
-        Disables all passive scanners
+        Disables all passive scan rules
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/disableAllScanners/', {'apikey': apikey})))
 
     def enable_scanners(self, ids, apikey=''):
         """
-        Enables all passive scanners with the given IDs (comma separated list of IDs)
+        Enables all passive scan rules with the given IDs (comma separated list of IDs)
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/enableScanners/', {'ids': ids, 'apikey': apikey})))
 
     def disable_scanners(self, ids, apikey=''):
         """
-        Disables all passive scanners with the given IDs (comma separated list of IDs)
+        Disables all passive scan rules with the given IDs (comma separated list of IDs)
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/disableScanners/', {'ids': ids, 'apikey': apikey})))
 
@@ -121,3 +128,9 @@ class pscan(object):
         Enables all passive scan tags.
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/enableAllTags/', {'apikey': apikey})))
+
+    def clear_queue(self, apikey=''):
+        """
+        Clears the passive scan queue.
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/clearQueue/', {'apikey': apikey})))

--- a/src/zapv2/replacer.py
+++ b/src/zapv2/replacer.py
@@ -35,7 +35,7 @@ class replacer(object):
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'replacer/view/rules/')))
 
-    def add_rule(self, description, enabled, matchtype, matchregex, matchstring, replacement=None, initiators=None, apikey=''):
+    def add_rule(self, description, enabled, matchtype, matchregex, matchstring, replacement=None, initiators=None, url=None, apikey=''):
         """
         Adds a replacer rule. For the parameters: desc is a user friendly description, enabled is true or false, matchType is one of [REQ_HEADER, REQ_HEADER_STR, REQ_BODY_STR, RESP_HEADER, RESP_HEADER_STR, RESP_BODY_STR], matchRegex should be true if the matchString should be treated as a regex otherwise false, matchString is the string that will be matched against, replacement is the replacement string, initiators may be blank (for all initiators) or a comma separated list of integers as defined in <a href="https://github.com/zaproxy/zaproxy/blob/main/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java">HttpSender</a>  
         This component is optional and therefore the API will only work if it is installed
@@ -45,6 +45,8 @@ class replacer(object):
             params['replacement'] = replacement
         if initiators is not None:
             params['initiators'] = initiators
+        if url is not None:
+            params['url'] = url
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'replacer/action/addRule/', params)))
 
     def remove_rule(self, description, apikey=''):

--- a/src/zapv2/selenium.py
+++ b/src/zapv2/selenium.py
@@ -35,6 +35,14 @@ class selenium(object):
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/view/optionBrowserExtensions/')))
 
     @property
+    def option_chrome_binary_path(self):
+        """
+        Returns the current path to Chrome binary
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/view/optionChromeBinaryPath/')))
+
+    @property
     def option_chrome_driver_path(self):
         """
         Returns the current path to ChromeDriver
@@ -79,6 +87,13 @@ class selenium(object):
         This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/view/optionPhantomJsBinaryPath/')))
+
+    def set_option_chrome_binary_path(self, string, apikey=''):
+        """
+        Sets the current path to Chrome binary
+        This component is optional and therefore the API will only work if it is installed
+        """
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionChromeBinaryPath/', {'String': string, 'apikey': apikey})))
 
     def set_option_chrome_driver_path(self, string, apikey=''):
         """

--- a/src/zapv2/spider.py
+++ b/src/zapv2/spider.py
@@ -30,6 +30,7 @@ class spider(object):
     def status(self, scanid=None):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         params = {}
         if scanid is not None:
@@ -39,6 +40,7 @@ class spider(object):
     def results(self, scanid=None):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         params = {}
         if scanid is not None:
@@ -48,6 +50,7 @@ class spider(object):
     def full_results(self, scanid):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/fullResults/', {'scanId': scanid})))
 
@@ -55,6 +58,7 @@ class spider(object):
     def scans(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/scans/')))
 
@@ -62,6 +66,7 @@ class spider(object):
     def excluded_from_scan(self):
         """
         Gets the regexes of URLs excluded from the spider scans.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/excludedFromScan/')))
 
@@ -69,12 +74,14 @@ class spider(object):
     def all_urls(self):
         """
         Returns a list of unique URLs from the history table based on HTTP messages added by the Spider.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/allUrls/')))
 
     def added_nodes(self, scanid=None):
         """
         Returns a list of the names of the nodes added to the Sites tree by the specified scan.
+        This component is optional and therefore the API will only work if it is installed
         """
         params = {}
         if scanid is not None:
@@ -85,6 +92,7 @@ class spider(object):
     def domains_always_in_scope(self):
         """
         Gets all the domains that are always in scope. For each domain the following are shown: the index, the value (domain), if enabled, and if specified as a regex.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/domainsAlwaysInScope/')))
 
@@ -92,6 +100,7 @@ class spider(object):
     def option_domains_always_in_scope(self):
         """
         Use view domainsAlwaysInScope instead.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionDomainsAlwaysInScope/')))
 
@@ -99,6 +108,7 @@ class spider(object):
     def option_domains_always_in_scope_enabled(self):
         """
         Use view domainsAlwaysInScope instead.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionDomainsAlwaysInScopeEnabled/')))
 
@@ -106,6 +116,7 @@ class spider(object):
     def option_handle_parameters(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionHandleParameters/')))
 
@@ -113,6 +124,7 @@ class spider(object):
     def option_max_children(self):
         """
         Gets the maximum number of child nodes (per node) that can be crawled, 0 means no limit.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionMaxChildren/')))
 
@@ -120,6 +132,7 @@ class spider(object):
     def option_max_depth(self):
         """
         Gets the maximum depth the spider can crawl, 0 if unlimited.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionMaxDepth/')))
 
@@ -127,6 +140,7 @@ class spider(object):
     def option_max_duration(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionMaxDuration/')))
 
@@ -134,6 +148,7 @@ class spider(object):
     def option_max_parse_size_bytes(self):
         """
         Gets the maximum size, in bytes, that a response might have to be parsed.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionMaxParseSizeBytes/')))
 
@@ -141,6 +156,7 @@ class spider(object):
     def option_max_scans_in_ui(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionMaxScansInUI/')))
 
@@ -148,27 +164,15 @@ class spider(object):
     def option_request_wait_time(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionRequestWaitTime/')))
-
-    @property
-    def option_scope(self):
-        """
-        
-        """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionScope/')))
-
-    @property
-    def option_scope_text(self):
-        """
-        
-        """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionScopeText/')))
 
     @property
     def option_skip_url_string(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionSkipURLString/')))
 
@@ -176,6 +180,7 @@ class spider(object):
     def option_thread_count(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionThreadCount/')))
 
@@ -183,6 +188,7 @@ class spider(object):
     def option_user_agent(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionUserAgent/')))
 
@@ -190,6 +196,7 @@ class spider(object):
     def option_accept_cookies(self):
         """
         Gets whether or not a spider process should accept cookies while spidering.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionAcceptCookies/')))
 
@@ -197,6 +204,7 @@ class spider(object):
     def option_handle_o_data_parameters_visited(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionHandleODataParametersVisited/')))
 
@@ -204,6 +212,7 @@ class spider(object):
     def option_parse_comments(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionParseComments/')))
 
@@ -211,6 +220,7 @@ class spider(object):
     def option_parse_git(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionParseGit/')))
 
@@ -218,6 +228,7 @@ class spider(object):
     def option_parse_robots_txt(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionParseRobotsTxt/')))
 
@@ -225,6 +236,7 @@ class spider(object):
     def option_parse_svn_entries(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionParseSVNEntries/')))
 
@@ -232,6 +244,7 @@ class spider(object):
     def option_parse_sitemap_xml(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionParseSitemapXml/')))
 
@@ -239,6 +252,7 @@ class spider(object):
     def option_post_form(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionPostForm/')))
 
@@ -246,6 +260,7 @@ class spider(object):
     def option_process_form(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionProcessForm/')))
 
@@ -253,6 +268,7 @@ class spider(object):
     def option_send_referer_header(self):
         """
         Gets whether or not the 'Referer' header should be sent while spidering.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionSendRefererHeader/')))
 
@@ -260,12 +276,14 @@ class spider(object):
     def option_show_advanced_dialog(self):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/view/optionShowAdvancedDialog/')))
 
     def scan(self, url=None, maxchildren=None, recurse=None, contextname=None, subtreeonly=None, apikey=''):
         """
         Runs the spider against the given URL (or context). Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, the 'recurse' parameter can be used to prevent the spider from seeding recursively, the parameter 'contextName' can be used to constrain the scan to a Context and the parameter 'subtreeOnly' allows to restrict the spider under a site's subtree (using the specified 'url').
+        This component is optional and therefore the API will only work if it is installed
         """
         params = {'apikey': apikey}
         if url is not None:
@@ -283,6 +301,7 @@ class spider(object):
     def scan_as_user(self, contextid, userid, url=None, maxchildren=None, recurse=None, subtreeonly=None, apikey=''):
         """
         Runs the spider from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
+        This component is optional and therefore the API will only work if it is installed
         """
         params = {'contextId': contextid, 'userId': userid, 'apikey': apikey}
         if url is not None:
@@ -298,18 +317,21 @@ class spider(object):
     def pause(self, scanid, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/pause/', {'scanId': scanid, 'apikey': apikey})))
 
     def resume(self, scanid, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/resume/', {'scanId': scanid, 'apikey': apikey})))
 
     def stop(self, scanid=None, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         params = {'apikey': apikey}
         if scanid is not None:
@@ -319,48 +341,56 @@ class spider(object):
     def remove_scan(self, scanid, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/removeScan/', {'scanId': scanid, 'apikey': apikey})))
 
     def pause_all_scans(self, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/pauseAllScans/', {'apikey': apikey})))
 
     def resume_all_scans(self, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/resumeAllScans/', {'apikey': apikey})))
 
     def stop_all_scans(self, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/stopAllScans/', {'apikey': apikey})))
 
     def remove_all_scans(self, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/removeAllScans/', {'apikey': apikey})))
 
     def clear_excluded_from_scan(self, apikey=''):
         """
         Clears the regexes of URLs excluded from the spider scans.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/clearExcludedFromScan/', {'apikey': apikey})))
 
     def exclude_from_scan(self, regex, apikey=''):
         """
         Adds a regex of URLs that should be excluded from the spider scans.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/excludeFromScan/', {'regex': regex, 'apikey': apikey})))
 
     def add_domain_always_in_scope(self, value, isregex=None, isenabled=None, apikey=''):
         """
         Adds a new domain that's always in scope, using the specified value. Optionally sets if the new entry is enabled (default, true) and whether or not the new value is specified as a regex (default, false).
+        This component is optional and therefore the API will only work if it is installed
         """
         params = {'value': value, 'apikey': apikey}
         if isregex is not None:
@@ -372,6 +402,7 @@ class spider(object):
     def modify_domain_always_in_scope(self, idx, value=None, isregex=None, isenabled=None, apikey=''):
         """
         Modifies a domain that's always in scope. Allows to modify the value, if enabled or if a regex. The domain is selected with its index, which can be obtained with the view domainsAlwaysInScope.
+        This component is optional and therefore the API will only work if it is installed
         """
         params = {'idx': idx, 'apikey': apikey}
         if value is not None:
@@ -385,149 +416,167 @@ class spider(object):
     def remove_domain_always_in_scope(self, idx, apikey=''):
         """
         Removes a domain that's always in scope, with the given index. The index can be obtained with the view domainsAlwaysInScope.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/removeDomainAlwaysInScope/', {'idx': idx, 'apikey': apikey})))
 
     def enable_all_domains_always_in_scope(self, apikey=''):
         """
         Enables all domains that are always in scope.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/enableAllDomainsAlwaysInScope/', {'apikey': apikey})))
 
     def disable_all_domains_always_in_scope(self, apikey=''):
         """
         Disables all domains that are always in scope.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/disableAllDomainsAlwaysInScope/', {'apikey': apikey})))
 
     def set_option_handle_parameters(self, string, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionHandleParameters/', {'String': string, 'apikey': apikey})))
-
-    def set_option_scope_string(self, string, apikey=''):
-        """
-        Use actions [add|modify|remove]DomainAlwaysInScope instead.
-        """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionScopeString/', {'String': string, 'apikey': apikey})))
 
     def set_option_skip_url_string(self, string, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionSkipURLString/', {'String': string, 'apikey': apikey})))
 
     def set_option_user_agent(self, string, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionUserAgent/', {'String': string, 'apikey': apikey})))
 
     def set_option_accept_cookies(self, boolean, apikey=''):
         """
         Sets whether or not a spider process should accept cookies while spidering.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionAcceptCookies/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_handle_o_data_parameters_visited(self, boolean, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionHandleODataParametersVisited/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_max_children(self, integer, apikey=''):
         """
         Sets the maximum number of child nodes (per node) that can be crawled, 0 means no limit.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxChildren/', {'Integer': integer, 'apikey': apikey})))
 
     def set_option_max_depth(self, integer, apikey=''):
         """
         Sets the maximum depth the spider can crawl, 0 for unlimited depth.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxDepth/', {'Integer': integer, 'apikey': apikey})))
 
     def set_option_max_duration(self, integer, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxDuration/', {'Integer': integer, 'apikey': apikey})))
 
     def set_option_max_parse_size_bytes(self, integer, apikey=''):
         """
         Sets the maximum size, in bytes, that a response might have to be parsed. This allows the spider to skip big responses/files.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxParseSizeBytes/', {'Integer': integer, 'apikey': apikey})))
 
     def set_option_max_scans_in_ui(self, integer, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxScansInUI/', {'Integer': integer, 'apikey': apikey})))
 
     def set_option_parse_comments(self, boolean, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseComments/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_parse_git(self, boolean, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseGit/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_parse_robots_txt(self, boolean, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseRobotsTxt/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_parse_svn_entries(self, boolean, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseSVNEntries/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_parse_sitemap_xml(self, boolean, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseSitemapXml/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_post_form(self, boolean, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionPostForm/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_process_form(self, boolean, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionProcessForm/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_request_wait_time(self, integer, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionRequestWaitTime/', {'Integer': integer, 'apikey': apikey})))
 
     def set_option_send_referer_header(self, boolean, apikey=''):
         """
         Sets whether or not the 'Referer' header should be sent while spidering.
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionSendRefererHeader/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_show_advanced_dialog(self, boolean, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionShowAdvancedDialog/', {'Boolean': boolean, 'apikey': apikey})))
 
     def set_option_thread_count(self, integer, apikey=''):
         """
         
+        This component is optional and therefore the API will only work if it is installed
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionThreadCount/', {'Integer': integer, 'apikey': apikey})))


### PR DESCRIPTION
Update core APIs for 2.12.0.

Add the APIs of the following add-ons:
 - Import/Export version 0.3.0.

Update the APIs of the following add-ons:
 - Network version 0.3.0;
 - Replacer version 11;
 - Selenium version 15.11.0;
 - Spider version 0.1.0.

Prepare release.
Remove Python 3.6 already EOL.
Test with Python 3.9.