### PR TITLE
Correctly pass scan rules' IDs in zap_example_api_script.py

### DIFF
--- a/src/examples/zap_example_api_script.py
+++ b/src/examples/zap_example_api_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 '''
 This script aims to be the most generic and the most explicit possible.

--- a/src/examples/zap_example_api_script.py
+++ b/src/examples/zap_example_api_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 '''
 This script aims to be the most generic and the most explicit possible.
@@ -354,6 +354,7 @@ if useScanPolicy:
         ascan.set_policy_attack_strength(id=policyId,
                                          attackstrength=attackStrength,
                                          scanpolicyname=scanPolicyName)
+    ascanIds = ",".join(str(id) for id in ascanIds)
     if isWhiteListPolicy:
         # Disable all active scanners in order to enable only what you need
         pprint('Disable all scanners -> ' +


### PR DESCRIPTION
In order for `enable_scanners(ids)` and `disable_scanners(ids)` to work, `ids` can't be in list format.

My solution was to add the following line to the example Python script:
```py
ascanIds = ",".join(str(id) for id in ascanIds)
```

Now, instead of passing in `[1, 2, 3, 4]`, we're passing in `"1,2,3,4"`, which is able to work for the API call.