### PR TITLE
Stop using function level API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Deprecated
+- The parameter `apikey` in the functions is no longer functional and will be removed in a future version.
+  The API key should be set when creating the API client (i.e. `ZAPv2(apikey='MyApiKey')`), which was added in the version 0.0.9, seven years ago.
 - The class `localProxies` will be removed in a future version, having been superseded by `network`.
 
 ### Removed

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -167,12 +167,6 @@ class ZAPv2(object):
         if self.__apikey is not None:
           self.session.headers['X-ZAP-API-Key'] = self.__apikey
 
-        query = query or {}
-        if self.__apikey is not None:
-          # Add the apikey to get params for backwards compatibility
-          if not query.get('apikey'):
-            query['apikey'] = self.__apikey
-
         response = self.session.get(url, params=query, proxies=self.__proxies, verify=False)
 
         if (self.__validate_status_code and response.status_code >= 300 and response.status_code < 500):

--- a/src/zapv2/accessControl.py
+++ b/src/zapv2/accessControl.py
@@ -46,7 +46,7 @@ class accessControl(object):
         Starts an Access Control scan with the given context ID and user ID. (Optional parameters: user ID for Unauthenticated user, boolean identifying whether or not Alerts are raised, and the Risk level for the Alerts.) [This assumes the Access Control rules were previously established via ZAP gui and the necessary Context exported/imported.]
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'contextId': contextid, 'userId': userid, 'apikey': apikey}
+        params = {'contextId': contextid, 'userId': userid}
         if scanasunauthuser is not None:
             params['scanAsUnAuthUser'] = scanasunauthuser
         if raisealert is not None:
@@ -60,4 +60,4 @@ class accessControl(object):
         Generates an Access Control report for the given context ID and saves it based on the provided filename (path). 
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'accessControl/action/writeHTMLreport/', {'contextId': contextid, 'fileName': filename, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'accessControl/action/writeHTMLreport/', {'contextId': contextid, 'fileName': filename})))

--- a/src/zapv2/acsrf.py
+++ b/src/zapv2/acsrf.py
@@ -45,25 +45,25 @@ class acsrf(object):
         """
         Adds an anti-CSRF token with the given name, enabled by default
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'acsrf/action/addOptionToken/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'acsrf/action/addOptionToken/', {'String': string})))
 
     def remove_option_token(self, string, apikey=''):
         """
         Removes the anti-CSRF token with the given name
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'acsrf/action/removeOptionToken/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'acsrf/action/removeOptionToken/', {'String': string})))
 
     def set_option_partial_matching_enabled(self, boolean, apikey=''):
         """
         Define if ZAP should detect CSRF tokens by searching for partial matches.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'acsrf/action/setOptionPartialMatchingEnabled/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'acsrf/action/setOptionPartialMatchingEnabled/', {'Boolean': boolean})))
 
     def gen_form(self, hrefid, actionurl=None, apikey=''):
         """
         Generate a form for testing lack of anti-CSRF tokens - typically invoked via ZAP
         """
-        params = {'hrefId': hrefid, 'apikey': apikey}
+        params = {'hrefId': hrefid}
         if actionurl is not None:
             params['actionUrl'] = actionurl
         return (self.zap._request_other(self.zap.base_other + 'acsrf/other/genForm/', params))

--- a/src/zapv2/ajaxSpider.py
+++ b/src/zapv2/ajaxSpider.py
@@ -163,7 +163,7 @@ class ajaxSpider(object):
         Runs the AJAX Spider against a given target.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'apikey': apikey}
+        params = {}
         if url is not None:
             params['url'] = url
         if inscope is not None:
@@ -179,7 +179,7 @@ class ajaxSpider(object):
         Runs the AJAX Spider from the perspective of a User of the web application.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'contextName': contextname, 'userName': username, 'apikey': apikey}
+        params = {'contextName': contextname, 'userName': username}
         if url is not None:
             params['url'] = url
         if subtreeonly is not None:
@@ -191,14 +191,14 @@ class ajaxSpider(object):
         Stops the AJAX Spider.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/stop/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/stop/', {})))
 
     def add_allowed_resource(self, regex, enabled=None, apikey=''):
         """
         Adds an allowed resource.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'regex': regex, 'apikey': apikey}
+        params = {'regex': regex}
         if enabled is not None:
             params['enabled'] = enabled
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/addAllowedResource/', params)))
@@ -208,7 +208,7 @@ class ajaxSpider(object):
         Adds an excluded element to a context.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'contextName': contextname, 'description': description, 'element': element, 'apikey': apikey}
+        params = {'contextName': contextname, 'description': description, 'element': element}
         if xpath is not None:
             params['xpath'] = xpath
         if text is not None:
@@ -226,7 +226,7 @@ class ajaxSpider(object):
         Modifies an excluded element of a context.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'contextName': contextname, 'description': description, 'element': element, 'apikey': apikey}
+        params = {'contextName': contextname, 'description': description, 'element': element}
         if descriptionnew is not None:
             params['descriptionNew'] = descriptionnew
         if xpath is not None:
@@ -246,88 +246,88 @@ class ajaxSpider(object):
         Removes an excluded element from a context.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/removeExcludedElement/', {'contextName': contextname, 'description': description, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/removeExcludedElement/', {'contextName': contextname, 'description': description})))
 
     def remove_allowed_resource(self, regex, apikey=''):
         """
         Removes an allowed resource.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/removeAllowedResource/', {'regex': regex, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/removeAllowedResource/', {'regex': regex})))
 
     def set_enabled_allowed_resource(self, regex, enabled, apikey=''):
         """
         Sets whether or not an allowed resource is enabled.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setEnabledAllowedResource/', {'regex': regex, 'enabled': enabled, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setEnabledAllowedResource/', {'regex': regex, 'enabled': enabled})))
 
     def set_option_browser_id(self, string, apikey=''):
         """
         Sets the configuration of the AJAX Spider to use one of the supported browsers.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionBrowserId/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionBrowserId/', {'String': string})))
 
     def set_option_click_default_elems(self, boolean, apikey=''):
         """
         Sets whether or not the the AJAX Spider will only click on the default HTML elements.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionClickDefaultElems/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionClickDefaultElems/', {'Boolean': boolean})))
 
     def set_option_click_elems_once(self, boolean, apikey=''):
         """
         When enabled, the crawler attempts to interact with each element (e.g., by clicking) only once.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionClickElemsOnce/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionClickElemsOnce/', {'Boolean': boolean})))
 
     def set_option_event_wait(self, integer, apikey=''):
         """
         Sets the time to wait after an event (in milliseconds). For example: the wait delay after the cursor hovers over an element, in order for a menu to display, etc.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionEventWait/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionEventWait/', {'Integer': integer})))
 
     def set_option_max_crawl_depth(self, integer, apikey=''):
         """
         Sets the maximum depth that the crawler can reach.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionMaxCrawlDepth/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionMaxCrawlDepth/', {'Integer': integer})))
 
     def set_option_max_crawl_states(self, integer, apikey=''):
         """
         Sets the maximum number of states that the crawler should crawl.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionMaxCrawlStates/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionMaxCrawlStates/', {'Integer': integer})))
 
     def set_option_max_duration(self, integer, apikey=''):
         """
         The maximum time that the crawler is allowed to run.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionMaxDuration/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionMaxDuration/', {'Integer': integer})))
 
     def set_option_number_of_browsers(self, integer, apikey=''):
         """
         Sets the number of windows to be used by AJAX Spider.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionNumberOfBrowsers/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionNumberOfBrowsers/', {'Integer': integer})))
 
     def set_option_random_inputs(self, boolean, apikey=''):
         """
         When enabled, inserts random values into form fields.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionRandomInputs/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionRandomInputs/', {'Boolean': boolean})))
 
     def set_option_reload_wait(self, integer, apikey=''):
         """
         Sets the time to wait after the page is loaded before interacting with it.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionReloadWait/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ajaxSpider/action/setOptionReloadWait/', {'Integer': integer})))

--- a/src/zapv2/alert.py
+++ b/src/zapv2/alert.py
@@ -94,31 +94,31 @@ class alert(object):
         """
         Deletes all alerts of the current session.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alert/action/deleteAllAlerts/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alert/action/deleteAllAlerts/', {})))
 
     def delete_alert(self, id, apikey=''):
         """
         Deletes the alert with the given ID. 
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alert/action/deleteAlert/', {'id': id, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alert/action/deleteAlert/', {'id': id})))
 
     def update_alerts_confidence(self, ids, confidenceid, apikey=''):
         """
         Update the confidence of the alerts.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alert/action/updateAlertsConfidence/', {'ids': ids, 'confidenceId': confidenceid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alert/action/updateAlertsConfidence/', {'ids': ids, 'confidenceId': confidenceid})))
 
     def update_alerts_risk(self, ids, riskid, apikey=''):
         """
         Update the risk of the alerts.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alert/action/updateAlertsRisk/', {'ids': ids, 'riskId': riskid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alert/action/updateAlertsRisk/', {'ids': ids, 'riskId': riskid})))
 
     def update_alert(self, id, name, riskid, confidenceid, description, param=None, attack=None, otherinfo=None, solution=None, references=None, evidence=None, cweid=None, wascid=None, apikey=''):
         """
         Update the alert with the given ID, with the provided details.
         """
-        params = {'id': id, 'name': name, 'riskId': riskid, 'confidenceId': confidenceid, 'description': description, 'apikey': apikey}
+        params = {'id': id, 'name': name, 'riskId': riskid, 'confidenceId': confidenceid, 'description': description}
         if param is not None:
             params['param'] = param
         if attack is not None:
@@ -141,7 +141,7 @@ class alert(object):
         """
         Add an alert associated with the given message ID, with the provided details. (The ID of the created alert is returned.)
         """
-        params = {'messageId': messageid, 'name': name, 'riskId': riskid, 'confidenceId': confidenceid, 'description': description, 'apikey': apikey}
+        params = {'messageId': messageid, 'name': name, 'riskId': riskid, 'confidenceId': confidenceid, 'description': description}
         if param is not None:
             params['param'] = param
         if attack is not None:

--- a/src/zapv2/alertFilter.py
+++ b/src/zapv2/alertFilter.py
@@ -47,7 +47,7 @@ class alertFilter(object):
         Adds a new alert filter for the context with the given ID. 
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'contextId': contextid, 'ruleId': ruleid, 'newLevel': newlevel, 'apikey': apikey}
+        params = {'contextId': contextid, 'ruleId': ruleid, 'newLevel': newlevel}
         if url is not None:
             params['url'] = url
         if urlisregex is not None:
@@ -75,7 +75,7 @@ class alertFilter(object):
         Removes an alert filter from the context with the given ID.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'contextId': contextid, 'ruleId': ruleid, 'newLevel': newlevel, 'apikey': apikey}
+        params = {'contextId': contextid, 'ruleId': ruleid, 'newLevel': newlevel}
         if url is not None:
             params['url'] = url
         if urlisregex is not None:
@@ -103,7 +103,7 @@ class alertFilter(object):
         Adds a new global alert filter. 
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'ruleId': ruleid, 'newLevel': newlevel, 'apikey': apikey}
+        params = {'ruleId': ruleid, 'newLevel': newlevel}
         if url is not None:
             params['url'] = url
         if urlisregex is not None:
@@ -131,7 +131,7 @@ class alertFilter(object):
         Removes a global alert filter.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'ruleId': ruleid, 'newLevel': newlevel, 'apikey': apikey}
+        params = {'ruleId': ruleid, 'newLevel': newlevel}
         if url is not None:
             params['url'] = url
         if urlisregex is not None:
@@ -159,39 +159,39 @@ class alertFilter(object):
         Applies all currently enabled Global and Context alert filters.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alertFilter/action/applyAll/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alertFilter/action/applyAll/', {})))
 
     def apply_context(self, apikey=''):
         """
         Applies all currently enabled Context alert filters.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alertFilter/action/applyContext/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alertFilter/action/applyContext/', {})))
 
     def apply_global(self, apikey=''):
         """
         Applies all currently enabled Global alert filters.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alertFilter/action/applyGlobal/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alertFilter/action/applyGlobal/', {})))
 
     def test_all(self, apikey=''):
         """
         Tests all currently enabled Global and Context alert filters.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alertFilter/action/testAll/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alertFilter/action/testAll/', {})))
 
     def test_context(self, apikey=''):
         """
         Tests all currently enabled Context alert filters.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alertFilter/action/testContext/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alertFilter/action/testContext/', {})))
 
     def test_global(self, apikey=''):
         """
         Tests all currently enabled Global alert filters.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alertFilter/action/testGlobal/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alertFilter/action/testGlobal/', {})))

--- a/src/zapv2/ascan.py
+++ b/src/zapv2/ascan.py
@@ -293,7 +293,7 @@ class ascan(object):
         """
         Runs the active scanner against the given URL or Context. Optionally, the 'recurse' parameter can be used to scan URLs under the given URL, the parameter 'inScopeOnly' can be used to constrain the scan to URLs that are in scope (ignored if a Context is specified), the parameter 'scanPolicyName' allows to specify the scan policy (if none is given it uses the default scan policy), the parameters 'method' and 'postData' allow to select a given request in conjunction with the given URL.
         """
-        params = {'apikey': apikey}
+        params = {}
         if url is not None:
             params['url'] = url
         if recurse is not None:
@@ -314,7 +314,7 @@ class ascan(object):
         """
         Active Scans from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
         """
-        params = {'apikey': apikey}
+        params = {}
         if url is not None:
             params['url'] = url
         if contextid is not None:
@@ -335,67 +335,67 @@ class ascan(object):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/pause/', {'scanId': scanid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/pause/', {'scanId': scanid})))
 
     def resume(self, scanid, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/resume/', {'scanId': scanid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/resume/', {'scanId': scanid})))
 
     def stop(self, scanid, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/stop/', {'scanId': scanid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/stop/', {'scanId': scanid})))
 
     def remove_scan(self, scanid, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/removeScan/', {'scanId': scanid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/removeScan/', {'scanId': scanid})))
 
     def pause_all_scans(self, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/pauseAllScans/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/pauseAllScans/', {})))
 
     def resume_all_scans(self, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/resumeAllScans/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/resumeAllScans/', {})))
 
     def stop_all_scans(self, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/stopAllScans/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/stopAllScans/', {})))
 
     def remove_all_scans(self, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/removeAllScans/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/removeAllScans/', {})))
 
     def clear_excluded_from_scan(self, apikey=''):
         """
         Clears the regexes of URLs excluded from the active scans.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/clearExcludedFromScan/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/clearExcludedFromScan/', {})))
 
     def exclude_from_scan(self, regex, apikey=''):
         """
         Adds a regex of URLs that should be excluded from the active scans.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/excludeFromScan/', {'regex': regex, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/excludeFromScan/', {'regex': regex})))
 
     def enable_all_scanners(self, scanpolicyname=None, apikey=''):
         """
         Enables all scan rules of the scan policy with the given name, or the default if none given.
         """
-        params = {'apikey': apikey}
+        params = {}
         if scanpolicyname is not None:
             params['scanPolicyName'] = scanpolicyname
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/enableAllScanners/', params)))
@@ -404,7 +404,7 @@ class ascan(object):
         """
         Disables all scan rules of the scan policy with the given name, or the default if none given.
         """
-        params = {'apikey': apikey}
+        params = {}
         if scanpolicyname is not None:
             params['scanPolicyName'] = scanpolicyname
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/disableAllScanners/', params)))
@@ -413,7 +413,7 @@ class ascan(object):
         """
         Enables the scan rules with the given IDs (comma separated list of IDs) of the scan policy with the given name, or the default if none given.
         """
-        params = {'ids': ids, 'apikey': apikey}
+        params = {'ids': ids}
         if scanpolicyname is not None:
             params['scanPolicyName'] = scanpolicyname
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/enableScanners/', params)))
@@ -422,7 +422,7 @@ class ascan(object):
         """
         Disables the scan rules with the given IDs (comma separated list of IDs) of the scan policy with the given name, or the default if none given.
         """
-        params = {'ids': ids, 'apikey': apikey}
+        params = {'ids': ids}
         if scanpolicyname is not None:
             params['scanPolicyName'] = scanpolicyname
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/disableScanners/', params)))
@@ -431,7 +431,7 @@ class ascan(object):
         """
         
         """
-        params = {'ids': ids, 'apikey': apikey}
+        params = {'ids': ids}
         if scanpolicyname is not None:
             params['scanPolicyName'] = scanpolicyname
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setEnabledPolicies/', params)))
@@ -440,7 +440,7 @@ class ascan(object):
         """
         
         """
-        params = {'id': id, 'attackStrength': attackstrength, 'apikey': apikey}
+        params = {'id': id, 'attackStrength': attackstrength}
         if scanpolicyname is not None:
             params['scanPolicyName'] = scanpolicyname
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setPolicyAttackStrength/', params)))
@@ -449,7 +449,7 @@ class ascan(object):
         """
         
         """
-        params = {'id': id, 'alertThreshold': alertthreshold, 'apikey': apikey}
+        params = {'id': id, 'alertThreshold': alertthreshold}
         if scanpolicyname is not None:
             params['scanPolicyName'] = scanpolicyname
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setPolicyAlertThreshold/', params)))
@@ -458,7 +458,7 @@ class ascan(object):
         """
         
         """
-        params = {'id': id, 'attackStrength': attackstrength, 'apikey': apikey}
+        params = {'id': id, 'attackStrength': attackstrength}
         if scanpolicyname is not None:
             params['scanPolicyName'] = scanpolicyname
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setScannerAttackStrength/', params)))
@@ -467,7 +467,7 @@ class ascan(object):
         """
         
         """
-        params = {'id': id, 'alertThreshold': alertthreshold, 'apikey': apikey}
+        params = {'id': id, 'alertThreshold': alertthreshold}
         if scanpolicyname is not None:
             params['scanPolicyName'] = scanpolicyname
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setScannerAlertThreshold/', params)))
@@ -476,7 +476,7 @@ class ascan(object):
         """
         
         """
-        params = {'scanPolicyName': scanpolicyname, 'apikey': apikey}
+        params = {'scanPolicyName': scanpolicyname}
         if alertthreshold is not None:
             params['alertThreshold'] = alertthreshold
         if attackstrength is not None:
@@ -487,13 +487,13 @@ class ascan(object):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/removeScanPolicy/', {'scanPolicyName': scanpolicyname, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/removeScanPolicy/', {'scanPolicyName': scanpolicyname})))
 
     def update_scan_policy(self, scanpolicyname, alertthreshold=None, attackstrength=None, apikey=''):
         """
         
         """
-        params = {'scanPolicyName': scanpolicyname, 'apikey': apikey}
+        params = {'scanPolicyName': scanpolicyname}
         if alertthreshold is not None:
             params['alertThreshold'] = alertthreshold
         if attackstrength is not None:
@@ -504,13 +504,13 @@ class ascan(object):
         """
         Imports a Scan Policy using the given file system path.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/importScanPolicy/', {'path': path, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/importScanPolicy/', {'path': path})))
 
     def add_excluded_param(self, name, type=None, url=None, apikey=''):
         """
         Adds a new parameter excluded from the scan, using the specified name. Optionally sets if the new entry applies to a specific URL (default, all URLs) and sets the ID of the type of the parameter (default, ID of any type). The type IDs can be obtained with the view excludedParamTypes. 
         """
-        params = {'name': name, 'apikey': apikey}
+        params = {'name': name}
         if type is not None:
             params['type'] = type
         if url is not None:
@@ -521,7 +521,7 @@ class ascan(object):
         """
         Modifies a parameter excluded from the scan. Allows to modify the name, the URL and the type of parameter. The parameter is selected with its index, which can be obtained with the view excludedParams.
         """
-        params = {'idx': idx, 'apikey': apikey}
+        params = {'idx': idx}
         if name is not None:
             params['name'] = name
         if type is not None:
@@ -534,148 +534,148 @@ class ascan(object):
         """
         Removes a parameter excluded from the scan, with the given index. The index can be obtained with the view excludedParams.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/removeExcludedParam/', {'idx': idx, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/removeExcludedParam/', {'idx': idx})))
 
     def skip_scanner(self, scanid, scannerid, apikey=''):
         """
         Skips the scan rule using the given IDs of the scan and the scan rule.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/skipScanner/', {'scanId': scanid, 'scannerId': scannerid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/skipScanner/', {'scanId': scanid, 'scannerId': scannerid})))
 
     def set_option_attack_policy(self, string, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionAttackPolicy/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionAttackPolicy/', {'String': string})))
 
     def set_option_default_policy(self, string, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionDefaultPolicy/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionDefaultPolicy/', {'String': string})))
 
     def set_option_add_query_param(self, boolean, apikey=''):
         """
         Sets whether or not the active scanner should add a query param to GET requests which do not have parameters to start with.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionAddQueryParam/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionAddQueryParam/', {'Boolean': boolean})))
 
     def set_option_allow_attack_on_start(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionAllowAttackOnStart/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionAllowAttackOnStart/', {'Boolean': boolean})))
 
     def set_option_delay_in_ms(self, integer, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionDelayInMs/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionDelayInMs/', {'Integer': integer})))
 
     def set_option_handle_anti_csrf_tokens(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionHandleAntiCSRFTokens/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionHandleAntiCSRFTokens/', {'Boolean': boolean})))
 
     def set_option_host_per_scan(self, integer, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionHostPerScan/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionHostPerScan/', {'Integer': integer})))
 
     def set_option_inject_plugin_id_in_header(self, boolean, apikey=''):
         """
         Sets whether or not the active scanner should inject the HTTP request header X-ZAP-Scan-ID, with the ID of the scan rule that's sending the requests.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionInjectPluginIdInHeader/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionInjectPluginIdInHeader/', {'Boolean': boolean})))
 
     def set_option_max_alerts_per_rule(self, integer, apikey=''):
         """
         Sets the maximum number of alerts that a rule can raise before being skipped.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionMaxAlertsPerRule/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionMaxAlertsPerRule/', {'Integer': integer})))
 
     def set_option_max_chart_time_in_mins(self, integer, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionMaxChartTimeInMins/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionMaxChartTimeInMins/', {'Integer': integer})))
 
     def set_option_max_results_to_list(self, integer, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionMaxResultsToList/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionMaxResultsToList/', {'Integer': integer})))
 
     def set_option_max_rule_duration_in_mins(self, integer, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionMaxRuleDurationInMins/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionMaxRuleDurationInMins/', {'Integer': integer})))
 
     def set_option_max_scan_duration_in_mins(self, integer, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionMaxScanDurationInMins/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionMaxScanDurationInMins/', {'Integer': integer})))
 
     def set_option_max_scans_in_ui(self, integer, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionMaxScansInUI/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionMaxScansInUI/', {'Integer': integer})))
 
     def set_option_prompt_in_attack_mode(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionPromptInAttackMode/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionPromptInAttackMode/', {'Boolean': boolean})))
 
     def set_option_prompt_to_clear_finished_scans(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionPromptToClearFinishedScans/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionPromptToClearFinishedScans/', {'Boolean': boolean})))
 
     def set_option_rescan_in_attack_mode(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionRescanInAttackMode/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionRescanInAttackMode/', {'Boolean': boolean})))
 
     def set_option_scan_headers_all_requests(self, boolean, apikey=''):
         """
         Sets whether or not the HTTP Headers of all requests should be scanned. Not just requests that send parameters, through the query or request body.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionScanHeadersAllRequests/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionScanHeadersAllRequests/', {'Boolean': boolean})))
 
     def set_option_scan_null_json_values(self, boolean, apikey=''):
         """
         Sets whether or not the active scanner should scan null JSON values.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionScanNullJsonValues/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionScanNullJsonValues/', {'Boolean': boolean})))
 
     def set_option_show_advanced_dialog(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionShowAdvancedDialog/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionShowAdvancedDialog/', {'Boolean': boolean})))
 
     def set_option_target_params_enabled_rpc(self, integer, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionTargetParamsEnabledRPC/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionTargetParamsEnabledRPC/', {'Integer': integer})))
 
     def set_option_target_params_injectable(self, integer, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionTargetParamsInjectable/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionTargetParamsInjectable/', {'Integer': integer})))
 
     def set_option_thread_per_host(self, integer, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionThreadPerHost/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ascan/action/setOptionThreadPerHost/', {'Integer': integer})))

--- a/src/zapv2/authentication.py
+++ b/src/zapv2/authentication.py
@@ -62,7 +62,7 @@ class authentication(object):
         """
         Sets the authentication method for the context with the given ID.
         """
-        params = {'contextId': contextid, 'authMethodName': authmethodname, 'apikey': apikey}
+        params = {'contextId': contextid, 'authMethodName': authmethodname}
         if authmethodconfigparams is not None:
             params['authMethodConfigParams'] = authmethodconfigparams
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'authentication/action/setAuthenticationMethod/', params)))
@@ -71,10 +71,10 @@ class authentication(object):
         """
         Sets the logged in indicator for the context with the given ID.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'authentication/action/setLoggedInIndicator/', {'contextId': contextid, 'loggedInIndicatorRegex': loggedinindicatorregex, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'authentication/action/setLoggedInIndicator/', {'contextId': contextid, 'loggedInIndicatorRegex': loggedinindicatorregex})))
 
     def set_logged_out_indicator(self, contextid, loggedoutindicatorregex, apikey=''):
         """
         Sets the logged out indicator for the context with the given ID.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'authentication/action/setLoggedOutIndicator/', {'contextId': contextid, 'loggedOutIndicatorRegex': loggedoutindicatorregex, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'authentication/action/setLoggedOutIndicator/', {'contextId': contextid, 'loggedOutIndicatorRegex': loggedoutindicatorregex})))

--- a/src/zapv2/authorization.py
+++ b/src/zapv2/authorization.py
@@ -37,7 +37,7 @@ class authorization(object):
         """
         Sets the authorization detection method for a context as one that identifies un-authorized messages based on: the message's status code or a regex pattern in the response's header or body. Also, whether all conditions must match or just some can be specified via the logicalOperator parameter, which accepts two values: "AND" (default), "OR".  
         """
-        params = {'contextId': contextid, 'apikey': apikey}
+        params = {'contextId': contextid}
         if headerregex is not None:
             params['headerRegex'] = headerregex
         if bodyregex is not None:

--- a/src/zapv2/automation.py
+++ b/src/zapv2/automation.py
@@ -37,10 +37,10 @@ class automation(object):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'automation/action/runPlan/', {'filePath': filepath, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'automation/action/runPlan/', {'filePath': filepath})))
 
     def end_delay_job(self, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'automation/action/endDelayJob/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'automation/action/endDelayJob/', {})))

--- a/src/zapv2/autoupdate.py
+++ b/src/zapv2/autoupdate.py
@@ -171,70 +171,70 @@ class autoupdate(object):
         """
         Downloads the latest release, if any 
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/downloadLatestRelease/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/downloadLatestRelease/', {})))
 
     def install_addon(self, id, apikey=''):
         """
         Installs or updates the specified add-on, returning when complete (i.e. not asynchronously)
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/installAddon/', {'id': id, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/installAddon/', {'id': id})))
 
     def install_local_addon(self, file, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/installLocalAddon/', {'file': file, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/installLocalAddon/', {'file': file})))
 
     def uninstall_addon(self, id, apikey=''):
         """
         Uninstalls the specified add-on 
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/uninstallAddon/', {'id': id, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/uninstallAddon/', {'id': id})))
 
     def set_option_check_addon_updates(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionCheckAddonUpdates/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionCheckAddonUpdates/', {'Boolean': boolean})))
 
     def set_option_check_on_start(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionCheckOnStart/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionCheckOnStart/', {'Boolean': boolean})))
 
     def set_option_download_new_release(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionDownloadNewRelease/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionDownloadNewRelease/', {'Boolean': boolean})))
 
     def set_option_install_addon_updates(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionInstallAddonUpdates/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionInstallAddonUpdates/', {'Boolean': boolean})))
 
     def set_option_install_scanner_rules(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionInstallScannerRules/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionInstallScannerRules/', {'Boolean': boolean})))
 
     def set_option_report_alpha_addons(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionReportAlphaAddons/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionReportAlphaAddons/', {'Boolean': boolean})))
 
     def set_option_report_beta_addons(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionReportBetaAddons/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionReportBetaAddons/', {'Boolean': boolean})))
 
     def set_option_report_release_addons(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionReportReleaseAddons/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'autoupdate/action/setOptionReportReleaseAddons/', {'Boolean': boolean})))

--- a/src/zapv2/brk.py
+++ b/src/zapv2/brk.py
@@ -59,7 +59,7 @@ class brk(object):
         """
         Controls the global break functionality. The type may be one of: http-all, http-request or http-response. The state may be true (for turning break on for the specified type) or false (for turning break off). Scope is not currently used.
         """
-        params = {'type': type, 'state': state, 'apikey': apikey}
+        params = {'type': type, 'state': state}
         if scope is not None:
             params['scope'] = scope
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'break/action/break/', params)))
@@ -68,7 +68,7 @@ class brk(object):
         """
         Overwrites the currently intercepted message with the data provided
         """
-        params = {'httpHeader': httpheader, 'apikey': apikey}
+        params = {'httpHeader': httpheader}
         if httpbody is not None:
             params['httpBody'] = httpbody
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'break/action/setHttpMessage/', params)))
@@ -77,28 +77,28 @@ class brk(object):
         """
         Submits the currently intercepted message and unsets the global request/response breakpoints
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'break/action/continue/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'break/action/continue/', {})))
 
     def step(self, apikey=''):
         """
         Submits the currently intercepted message, the next request or response will automatically be intercepted
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'break/action/step/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'break/action/step/', {})))
 
     def drop(self, apikey=''):
         """
         Drops the currently intercepted message
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'break/action/drop/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'break/action/drop/', {})))
 
     def add_http_breakpoint(self, string, location, match, inverse, ignorecase, apikey=''):
         """
         Adds a custom HTTP breakpoint. The string is the string to match. Location may be one of: url, request_header, request_body, response_header or response_body. Match may be: contains or regex. Inverse (match) may be true or false. Lastly, ignorecase (when matching the string) may be true or false.  
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'break/action/addHttpBreakpoint/', {'string': string, 'location': location, 'match': match, 'inverse': inverse, 'ignorecase': ignorecase, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'break/action/addHttpBreakpoint/', {'string': string, 'location': location, 'match': match, 'inverse': inverse, 'ignorecase': ignorecase})))
 
     def remove_http_breakpoint(self, string, location, match, inverse, ignorecase, apikey=''):
         """
         Removes the specified breakpoint
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'break/action/removeHttpBreakpoint/', {'string': string, 'location': location, 'match': match, 'inverse': inverse, 'ignorecase': ignorecase, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'break/action/removeHttpBreakpoint/', {'string': string, 'location': location, 'match': match, 'inverse': inverse, 'ignorecase': ignorecase})))

--- a/src/zapv2/context.py
+++ b/src/zapv2/context.py
@@ -81,25 +81,25 @@ class context(object):
         """
         Add exclude regex to context
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/excludeFromContext/', {'contextName': contextname, 'regex': regex, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/excludeFromContext/', {'contextName': contextname, 'regex': regex})))
 
     def include_in_context(self, contextname, regex, apikey=''):
         """
         Add include regex to context
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/includeInContext/', {'contextName': contextname, 'regex': regex, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/includeInContext/', {'contextName': contextname, 'regex': regex})))
 
     def set_context_regexs(self, contextname, incregexs, excregexs, apikey=''):
         """
         Set the regexs to include and exclude for a context, both supplied as JSON string arrays
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/setContextRegexs/', {'contextName': contextname, 'incRegexs': incregexs, 'excRegexs': excregexs, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/setContextRegexs/', {'contextName': contextname, 'incRegexs': incregexs, 'excRegexs': excregexs})))
 
     def set_context_checking_strategy(self, contextname, checkingstrategy, pollurl=None, polldata=None, pollheaders=None, pollfrequency=None, pollfrequencyunits=None, apikey=''):
         """
         Set the checking strategy for a context - this defines how ZAP checks that a request is authenticated
         """
-        params = {'contextName': contextname, 'checkingStrategy': checkingstrategy, 'apikey': apikey}
+        params = {'contextName': contextname, 'checkingStrategy': checkingstrategy}
         if pollurl is not None:
             params['pollUrl'] = pollurl
         if polldata is not None:
@@ -116,52 +116,52 @@ class context(object):
         """
         Creates a new context with the given name in the current session
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/newContext/', {'contextName': contextname, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/newContext/', {'contextName': contextname})))
 
     def remove_context(self, contextname, apikey=''):
         """
         Removes a context in the current session
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/removeContext/', {'contextName': contextname, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/removeContext/', {'contextName': contextname})))
 
     def export_context(self, contextname, contextfile, apikey=''):
         """
         Exports the context with the given name to a file. If a relative file path is specified it will be resolved against the "contexts" directory in ZAP "home" dir.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/exportContext/', {'contextName': contextname, 'contextFile': contextfile, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/exportContext/', {'contextName': contextname, 'contextFile': contextfile})))
 
     def import_context(self, contextfile, apikey=''):
         """
         Imports a context from a file. If a relative file path is specified it will be resolved against the "contexts" directory in ZAP "home" dir.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/importContext/', {'contextFile': contextfile, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/importContext/', {'contextFile': contextfile})))
 
     def include_context_technologies(self, contextname, technologynames, apikey=''):
         """
         Includes technologies with the given names, separated by a comma, to a context
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/includeContextTechnologies/', {'contextName': contextname, 'technologyNames': technologynames, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/includeContextTechnologies/', {'contextName': contextname, 'technologyNames': technologynames})))
 
     def include_all_context_technologies(self, contextname, apikey=''):
         """
         Includes all built in technologies in to a context
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/includeAllContextTechnologies/', {'contextName': contextname, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/includeAllContextTechnologies/', {'contextName': contextname})))
 
     def exclude_context_technologies(self, contextname, technologynames, apikey=''):
         """
         Excludes technologies with the given names, separated by a comma, from a context
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/excludeContextTechnologies/', {'contextName': contextname, 'technologyNames': technologynames, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/excludeContextTechnologies/', {'contextName': contextname, 'technologyNames': technologynames})))
 
     def exclude_all_context_technologies(self, contextname, apikey=''):
         """
         Excludes all built in technologies from a context
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/excludeAllContextTechnologies/', {'contextName': contextname, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/excludeAllContextTechnologies/', {'contextName': contextname})))
 
     def set_context_in_scope(self, contextname, booleaninscope, apikey=''):
         """
         Sets a context to in scope (contexts are in scope by default)
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/setContextInScope/', {'contextName': contextname, 'booleanInScope': booleaninscope, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'context/action/setContextInScope/', {'contextName': contextname, 'booleanInScope': booleaninscope})))

--- a/src/zapv2/core.py
+++ b/src/zapv2/core.py
@@ -334,7 +334,7 @@ class core(object):
         """
         Convenient and simple action to access a URL, optionally following redirections. Returns the request sent and response received and followed redirections, if any. Other actions are available which offer more control on what is sent, like, 'sendRequest' or 'sendHarRequest'.
         """
-        params = {'url': url, 'apikey': apikey}
+        params = {'url': url}
         if followredirects is not None:
             params['followRedirects'] = followredirects
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/accessUrl/', params)))
@@ -343,13 +343,13 @@ class core(object):
         """
         Shuts down ZAP
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/shutdown/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/shutdown/', {})))
 
     def new_session(self, name=None, overwrite=None, apikey=''):
         """
         Creates a new session, optionally overwriting existing files. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
         """
-        params = {'apikey': apikey}
+        params = {}
         if name is not None:
             params['name'] = name
         if overwrite is not None:
@@ -360,13 +360,13 @@ class core(object):
         """
         Loads the session with the given name. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/loadSession/', {'name': name, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/loadSession/', {'name': name})))
 
     def save_session(self, name, overwrite=None, apikey=''):
         """
         Saves the session.
         """
-        params = {'name': name, 'apikey': apikey}
+        params = {'name': name}
         if overwrite is not None:
             params['overwrite'] = overwrite
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/saveSession/', params)))
@@ -375,7 +375,7 @@ class core(object):
         """
         Snapshots the session, optionally with the given name, and overwriting existing files. If no name is specified the name of the current session with a timestamp appended is used. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
         """
-        params = {'apikey': apikey}
+        params = {}
         if name is not None:
             params['name'] = name
         if overwrite is not None:
@@ -386,37 +386,37 @@ class core(object):
         """
         Clears the regexes of URLs excluded from the local proxies.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/clearExcludedFromProxy/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/clearExcludedFromProxy/', {})))
 
     def exclude_from_proxy(self, regex, apikey=''):
         """
         Adds a regex of URLs that should be excluded from the local proxies.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/excludeFromProxy/', {'regex': regex, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/excludeFromProxy/', {'regex': regex})))
 
     def set_home_directory(self, dir, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setHomeDirectory/', {'dir': dir, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setHomeDirectory/', {'dir': dir})))
 
     def set_mode(self, mode, apikey=''):
         """
         Sets the mode, which may be one of [safe, protect, standard, attack]
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setMode/', {'mode': mode, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setMode/', {'mode': mode})))
 
     def generate_root_ca(self, apikey=''):
         """
         Generates a new Root CA certificate for the local proxies.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/generateRootCA/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/generateRootCA/', {})))
 
     def send_request(self, request, followredirects=None, apikey=''):
         """
         Sends the HTTP request, optionally following redirections. Returns the request sent and response received and followed redirections, if any. The Mode is enforced when sending the request (and following redirections), custom manual requests are not allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
         """
-        params = {'request': request, 'apikey': apikey}
+        params = {'request': request}
         if followredirects is not None:
             params['followRedirects'] = followredirects
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/sendRequest/', params)))
@@ -425,13 +425,13 @@ class core(object):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/runGarbageCollection/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/runGarbageCollection/', {})))
 
     def delete_site_node(self, url, method=None, postdata=None, apikey=''):
         """
         Deletes the site node found in the Sites Tree on the basis of the URL, HTTP method, and post data (if applicable and specified). 
         """
-        params = {'url': url, 'apikey': apikey}
+        params = {'url': url}
         if method is not None:
             params['method'] = method
         if postdata is not None:
@@ -442,7 +442,7 @@ class core(object):
         """
         Adds a domain to be excluded from the outgoing proxy, using the specified value. Optionally sets if the new entry is enabled (default, true) and whether or not the new value is specified as a regex (default, false).
         """
-        params = {'value': value, 'apikey': apikey}
+        params = {'value': value}
         if isregex is not None:
             params['isRegex'] = isregex
         if isenabled is not None:
@@ -453,7 +453,7 @@ class core(object):
         """
         Modifies a domain excluded from the outgoing proxy. Allows to modify the value, if enabled or if a regex. The domain is selected with its index, which can be obtained with the view proxyChainExcludedDomains.
         """
-        params = {'idx': idx, 'apikey': apikey}
+        params = {'idx': idx}
         if value is not None:
             params['value'] = value
         if isregex is not None:
@@ -466,37 +466,37 @@ class core(object):
         """
         Removes a domain excluded from the outgoing proxy, with the given index. The index can be obtained with the view proxyChainExcludedDomains.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/removeProxyChainExcludedDomain/', {'idx': idx, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/removeProxyChainExcludedDomain/', {'idx': idx})))
 
     def enable_all_proxy_chain_excluded_domains(self, apikey=''):
         """
         Enables all domains excluded from the outgoing proxy.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/enableAllProxyChainExcludedDomains/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/enableAllProxyChainExcludedDomains/', {})))
 
     def disable_all_proxy_chain_excluded_domains(self, apikey=''):
         """
         Disables all domains excluded from the outgoing proxy.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/disableAllProxyChainExcludedDomains/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/disableAllProxyChainExcludedDomains/', {})))
 
     def set_option_maximum_alert_instances(self, numberofinstances, apikey=''):
         """
         Sets the maximum number of alert instances to include in a report. A value of zero is treated as unlimited.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionMaximumAlertInstances/', {'numberOfInstances': numberofinstances, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionMaximumAlertInstances/', {'numberOfInstances': numberofinstances})))
 
     def set_option_merge_related_alerts(self, enabled, apikey=''):
         """
         Sets whether or not related alerts will be merged in any reports generated.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionMergeRelatedAlerts/', {'enabled': enabled, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionMergeRelatedAlerts/', {'enabled': enabled})))
 
     def set_option_alert_overrides_file_path(self, filepath=None, apikey=''):
         """
         Sets (or clears, if empty) the path to the file with alert overrides.
         """
-        params = {'apikey': apikey}
+        params = {}
         if filepath is not None:
             params['filePath'] = filepath
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionAlertOverridesFilePath/', params)))
@@ -505,7 +505,7 @@ class core(object):
         """
         Enables use of a PKCS12 client certificate for the certificate with the given file system path, password, and optional index.
         """
-        params = {'filePath': filepath, 'password': password, 'apikey': apikey}
+        params = {'filePath': filepath, 'password': password}
         if index is not None:
             params['index'] = index
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/enablePKCS12ClientCertificate/', params)))
@@ -514,163 +514,163 @@ class core(object):
         """
         Disables the option for use of client certificates.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/disableClientCertificate/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/disableClientCertificate/', {})))
 
     def delete_all_alerts(self, apikey=''):
         """
         Deletes all alerts of the current session.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/deleteAllAlerts/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/deleteAllAlerts/', {})))
 
     def delete_alert(self, id, apikey=''):
         """
         Deletes the alert with the given ID. 
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/deleteAlert/', {'id': id, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/deleteAlert/', {'id': id})))
 
     def set_option_default_user_agent(self, string, apikey=''):
         """
         Sets the user agent that ZAP should use when creating HTTP messages (for example, spider messages or CONNECT requests to outgoing proxy).
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionDefaultUserAgent/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionDefaultUserAgent/', {'String': string})))
 
     def set_option_dns_ttl_successful_queries(self, integer, apikey=''):
         """
         Sets the TTL (in seconds) of successful DNS queries (applies after ZAP restart).
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionDnsTtlSuccessfulQueries/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionDnsTtlSuccessfulQueries/', {'Integer': integer})))
 
     def set_option_http_state_enabled(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionHttpStateEnabled/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionHttpStateEnabled/', {'Boolean': boolean})))
 
     def set_option_proxy_chain_name(self, string, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainName/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainName/', {'String': string})))
 
     def set_option_proxy_chain_password(self, string, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainPassword/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainPassword/', {'String': string})))
 
     def set_option_proxy_chain_port(self, integer, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainPort/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainPort/', {'Integer': integer})))
 
     def set_option_proxy_chain_prompt(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainPrompt/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainPrompt/', {'Boolean': boolean})))
 
     def set_option_proxy_chain_realm(self, string, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainRealm/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainRealm/', {'String': string})))
 
     def set_option_proxy_chain_skip_name(self, string, apikey=''):
         """
         Use actions [add|modify|remove]ProxyChainExcludedDomain instead.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainSkipName/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainSkipName/', {'String': string})))
 
     def set_option_proxy_chain_user_name(self, string, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainUserName/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionProxyChainUserName/', {'String': string})))
 
     def set_option_single_cookie_request_header(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionSingleCookieRequestHeader/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionSingleCookieRequestHeader/', {'Boolean': boolean})))
 
     def set_option_timeout_in_secs(self, integer, apikey=''):
         """
         Sets the connection time out (in seconds).
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionTimeoutInSecs/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionTimeoutInSecs/', {'Integer': integer})))
 
     def set_option_use_proxy_chain(self, boolean, apikey=''):
         """
         Sets whether or not the outgoing proxy should be used. The address/hostname of the outgoing proxy must be set to enable this option.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionUseProxyChain/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionUseProxyChain/', {'Boolean': boolean})))
 
     def set_option_use_proxy_chain_auth(self, boolean, apikey=''):
         """
         
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionUseProxyChainAuth/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionUseProxyChainAuth/', {'Boolean': boolean})))
 
     def set_option_use_socks_proxy(self, boolean, apikey=''):
         """
         Sets whether or not the SOCKS proxy should be used.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionUseSocksProxy/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'core/action/setOptionUseSocksProxy/', {'Boolean': boolean})))
 
     def proxy_pac(self, apikey=''):
         """
         
         """
-        return (self.zap._request_other(self.zap.base_other + 'core/other/proxy.pac/', {'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'core/other/proxy.pac/', {}))
 
     def rootcert(self, apikey=''):
         """
         Gets the Root CA certificate used by the local proxies.
         """
-        return (self.zap._request_other(self.zap.base_other + 'core/other/rootcert/', {'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'core/other/rootcert/', {}))
 
     def setproxy(self, proxy, apikey=''):
         """
         
         """
-        return (self.zap._request_other(self.zap.base_other + 'core/other/setproxy/', {'proxy': proxy, 'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'core/other/setproxy/', {'proxy': proxy}))
 
     def xmlreport(self, apikey=''):
         """
         Generates a report in XML format
         """
-        return (self.zap._request_other(self.zap.base_other + 'core/other/xmlreport/', {'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'core/other/xmlreport/', {}))
 
     def htmlreport(self, apikey=''):
         """
         Generates a report in HTML format
         """
-        return (self.zap._request_other(self.zap.base_other + 'core/other/htmlreport/', {'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'core/other/htmlreport/', {}))
 
     def jsonreport(self, apikey=''):
         """
         Generates a report in JSON format
         """
-        return (self.zap._request_other(self.zap.base_other + 'core/other/jsonreport/', {'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'core/other/jsonreport/', {}))
 
     def mdreport(self, apikey=''):
         """
         Generates a report in Markdown format
         """
-        return (self.zap._request_other(self.zap.base_other + 'core/other/mdreport/', {'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'core/other/mdreport/', {}))
 
     def message_har(self, id, apikey=''):
         """
         Gets the message with the given ID in HAR format
         """
-        return (self.zap._request_other(self.zap.base_other + 'core/other/messageHar/', {'id': id, 'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'core/other/messageHar/', {'id': id}))
 
     def messages_har(self, baseurl=None, start=None, count=None, apikey=''):
         """
         Gets the HTTP messages sent through/by ZAP, in HAR format, optionally filtered by URL and paginated with 'start' position and 'count' of messages
         """
-        params = {'apikey': apikey}
+        params = {}
         if baseurl is not None:
             params['baseurl'] = baseurl
         if start is not None:
@@ -683,13 +683,13 @@ class core(object):
         """
         Gets the HTTP messages with the given IDs, in HAR format.
         """
-        return (self.zap._request_other(self.zap.base_other + 'core/other/messagesHarById/', {'ids': ids, 'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'core/other/messagesHarById/', {'ids': ids}))
 
     def send_har_request(self, request, followredirects=None, apikey=''):
         """
         Sends the first HAR request entry, optionally following redirections. Returns, in HAR format, the request sent and response received and followed redirections, if any. The Mode is enforced when sending the request (and following redirections), custom manual requests are not allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
         """
-        params = {'request': request, 'apikey': apikey}
+        params = {'request': request}
         if followredirects is not None:
             params['followRedirects'] = followredirects
         return (self.zap._request_other(self.zap.base_other + 'core/other/sendHarRequest/', params))

--- a/src/zapv2/exim.py
+++ b/src/zapv2/exim.py
@@ -32,35 +32,35 @@ class exim(object):
         Imports a HAR file.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'exim/action/importHar/', {'filePath': filepath, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'exim/action/importHar/', {'filePath': filepath})))
 
     def import_urls(self, filepath, apikey=''):
         """
         Imports URLs (one per line) from the file with the given file system path.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'exim/action/importUrls/', {'filePath': filepath, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'exim/action/importUrls/', {'filePath': filepath})))
 
     def import_zap_logs(self, filepath, apikey=''):
         """
         Imports previously exported ZAP messages from the file with the given file system path.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'exim/action/importZapLogs/', {'filePath': filepath, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'exim/action/importZapLogs/', {'filePath': filepath})))
 
     def import_modsec_2_logs(self, filepath, apikey=''):
         """
         Imports ModSecurity2 logs from the file with the given file system path.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'exim/action/importModsec2Logs/', {'filePath': filepath, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'exim/action/importModsec2Logs/', {'filePath': filepath})))
 
     def export_har(self, baseurl=None, start=None, count=None, apikey=''):
         """
         Gets the HTTP messages sent through/by ZAP, in HAR format, optionally filtered by URL and paginated with 'start' position and 'count' of messages
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'apikey': apikey}
+        params = {}
         if baseurl is not None:
             params['baseurl'] = baseurl
         if start is not None:
@@ -74,14 +74,14 @@ class exim(object):
         Gets the HTTP messages with the given IDs, in HAR format.
         This component is optional and therefore the API will only work if it is installed
         """
-        return (self.zap._request_other(self.zap.base_other + 'exim/other/exportHarById/', {'ids': ids, 'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'exim/other/exportHarById/', {'ids': ids}))
 
     def send_har_request(self, request, followredirects=None, apikey=''):
         """
         Sends the first HAR request entry, optionally following redirections. Returns, in HAR format, the request sent and response received and followed redirections, if any. The Mode is enforced when sending the request (and following redirections), custom manual requests are not allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'request': request, 'apikey': apikey}
+        params = {'request': request}
         if followredirects is not None:
             params['followRedirects'] = followredirects
         return (self.zap._request_other(self.zap.base_other + 'exim/other/sendHarRequest/', params))

--- a/src/zapv2/forcedUser.py
+++ b/src/zapv2/forcedUser.py
@@ -44,10 +44,10 @@ class forcedUser(object):
         """
         Sets the user (ID) that should be used in 'forced user' mode for the given context (ID)
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'forcedUser/action/setForcedUser/', {'contextId': contextid, 'userId': userid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'forcedUser/action/setForcedUser/', {'contextId': contextid, 'userId': userid})))
 
     def set_forced_user_mode_enabled(self, boolean, apikey=''):
         """
         Sets if 'forced user' mode should be enabled or not
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'forcedUser/action/setForcedUserModeEnabled/', {'boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'forcedUser/action/setForcedUserModeEnabled/', {'boolean': boolean})))

--- a/src/zapv2/graphql.py
+++ b/src/zapv2/graphql.py
@@ -104,14 +104,14 @@ class graphql(object):
         Imports a GraphQL Schema from a File.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/importFile/', {'endurl': endurl, 'file': file, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/importFile/', {'endurl': endurl, 'file': file})))
 
     def import_url(self, endurl, url=None, apikey=''):
         """
         Imports a GraphQL Schema from a URL.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'endurl': endurl, 'apikey': apikey}
+        params = {'endurl': endurl}
         if url is not None:
             params['url'] = url
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/importUrl/', params)))
@@ -121,60 +121,60 @@ class graphql(object):
         Sets how arguments are specified.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionArgsType/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionArgsType/', {'String': string})))
 
     def set_option_query_split_type(self, string, apikey=''):
         """
         Sets the level for which a single query is generated.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionQuerySplitType/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionQuerySplitType/', {'String': string})))
 
     def set_option_request_method(self, string, apikey=''):
         """
         Sets the request method.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionRequestMethod/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionRequestMethod/', {'String': string})))
 
     def set_option_lenient_max_query_depth_enabled(self, boolean, apikey=''):
         """
         Sets whether or not Maximum Query Depth is enforced leniently.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionLenientMaxQueryDepthEnabled/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionLenientMaxQueryDepthEnabled/', {'Boolean': boolean})))
 
     def set_option_max_additional_query_depth(self, integer, apikey=''):
         """
         Sets the maximum additional query generation depth (used if enforced leniently).
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionMaxAdditionalQueryDepth/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionMaxAdditionalQueryDepth/', {'Integer': integer})))
 
     def set_option_max_args_depth(self, integer, apikey=''):
         """
         Sets the maximum arguments generation depth.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionMaxArgsDepth/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionMaxArgsDepth/', {'Integer': integer})))
 
     def set_option_max_query_depth(self, integer, apikey=''):
         """
         Sets the maximum query generation depth.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionMaxQueryDepth/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionMaxQueryDepth/', {'Integer': integer})))
 
     def set_option_optional_args_enabled(self, boolean, apikey=''):
         """
         Sets whether or not Optional Arguments should be specified.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionOptionalArgsEnabled/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionOptionalArgsEnabled/', {'Boolean': boolean})))
 
     def set_option_query_gen_enabled(self, boolean, apikey=''):
         """
         Sets whether the query generator is enabled.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionQueryGenEnabled/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'graphql/action/setOptionQueryGenEnabled/', {'Boolean': boolean})))

--- a/src/zapv2/httpSessions.py
+++ b/src/zapv2/httpSessions.py
@@ -66,7 +66,7 @@ class httpSessions(object):
         """
         Creates an empty session for the given site. Optionally with the given name.
         """
-        params = {'site': site, 'apikey': apikey}
+        params = {'site': site}
         if session is not None:
             params['session'] = session
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/createEmptySession/', params)))
@@ -75,49 +75,49 @@ class httpSessions(object):
         """
         Removes the session from the given site.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/removeSession/', {'site': site, 'session': session, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/removeSession/', {'site': site, 'session': session})))
 
     def set_active_session(self, site, session, apikey=''):
         """
         Sets the given session as active for the given site.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/setActiveSession/', {'site': site, 'session': session, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/setActiveSession/', {'site': site, 'session': session})))
 
     def unset_active_session(self, site, apikey=''):
         """
         Unsets the active session of the given site.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/unsetActiveSession/', {'site': site, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/unsetActiveSession/', {'site': site})))
 
     def add_session_token(self, site, sessiontoken, apikey=''):
         """
         Adds the session token to the given site.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/addSessionToken/', {'site': site, 'sessionToken': sessiontoken, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/addSessionToken/', {'site': site, 'sessionToken': sessiontoken})))
 
     def remove_session_token(self, site, sessiontoken, apikey=''):
         """
         Removes the session token from the given site.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/removeSessionToken/', {'site': site, 'sessionToken': sessiontoken, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/removeSessionToken/', {'site': site, 'sessionToken': sessiontoken})))
 
     def set_session_token_value(self, site, session, sessiontoken, tokenvalue, apikey=''):
         """
         Sets the value of the session token of the given session for the given site.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/setSessionTokenValue/', {'site': site, 'session': session, 'sessionToken': sessiontoken, 'tokenValue': tokenvalue, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/setSessionTokenValue/', {'site': site, 'session': session, 'sessionToken': sessiontoken, 'tokenValue': tokenvalue})))
 
     def rename_session(self, site, oldsessionname, newsessionname, apikey=''):
         """
         Renames the session of the given site.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/renameSession/', {'site': site, 'oldSessionName': oldsessionname, 'newSessionName': newsessionname, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/renameSession/', {'site': site, 'oldSessionName': oldsessionname, 'newSessionName': newsessionname})))
 
     def add_default_session_token(self, sessiontoken, tokenenabled=None, apikey=''):
         """
         Adds a default session token with the given name and enabled state.
         """
-        params = {'sessionToken': sessiontoken, 'apikey': apikey}
+        params = {'sessionToken': sessiontoken}
         if tokenenabled is not None:
             params['tokenEnabled'] = tokenenabled
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/addDefaultSessionToken/', params)))
@@ -126,10 +126,10 @@ class httpSessions(object):
         """
         Sets whether or not the default session token with the given name is enabled.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/setDefaultSessionTokenEnabled/', {'sessionToken': sessiontoken, 'tokenEnabled': tokenenabled, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/setDefaultSessionTokenEnabled/', {'sessionToken': sessiontoken, 'tokenEnabled': tokenenabled})))
 
     def remove_default_session_token(self, sessiontoken, apikey=''):
         """
         Removes the default session token with the given name.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/removeDefaultSessionToken/', {'sessionToken': sessiontoken, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'httpSessions/action/removeDefaultSessionToken/', {'sessionToken': sessiontoken})))

--- a/src/zapv2/localProxies.py
+++ b/src/zapv2/localProxies.py
@@ -38,7 +38,7 @@ class localProxies(object):
         """
         Adds an new proxy using the details supplied.
         """
-        params = {'address': address, 'port': port, 'apikey': apikey}
+        params = {'address': address, 'port': port}
         if behindnat is not None:
             params['behindNat'] = behindnat
         if alwaysdecodezip is not None:
@@ -51,4 +51,4 @@ class localProxies(object):
         """
         Removes the additional proxy with the specified address and port.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'localProxies/action/removeAdditionalProxy/', {'address': address, 'port': port, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'localProxies/action/removeAdditionalProxy/', {'address': address, 'port': port})))

--- a/src/zapv2/network.py
+++ b/src/zapv2/network.py
@@ -160,35 +160,35 @@ class network(object):
         Generates a new Root CA certificate, used to issue server certificates.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/generateRootCaCert/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/generateRootCaCert/', {})))
 
     def import_root_ca_cert(self, filepath, apikey=''):
         """
         Imports a Root CA certificate to be used to issue server certificates.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/importRootCaCert/', {'filePath': filepath, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/importRootCaCert/', {'filePath': filepath})))
 
     def set_root_ca_cert_validity(self, validity, apikey=''):
         """
         Sets the Root CA certificate validity. Used when generating a new Root CA certificate.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setRootCaCertValidity/', {'validity': validity, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setRootCaCertValidity/', {'validity': validity})))
 
     def set_server_cert_validity(self, validity, apikey=''):
         """
         Sets the server certificate validity. Used when generating server certificates.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setServerCertValidity/', {'validity': validity, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setServerCertValidity/', {'validity': validity})))
 
     def add_alias(self, name, enabled=None, apikey=''):
         """
         Adds an alias for the local servers/proxies.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'name': name, 'apikey': apikey}
+        params = {'name': name}
         if enabled is not None:
             params['enabled'] = enabled
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/addAlias/', params)))
@@ -198,7 +198,7 @@ class network(object):
         Adds a local server/proxy.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'address': address, 'port': port, 'apikey': apikey}
+        params = {'address': address, 'port': port}
         if api is not None:
             params['api'] = api
         if proxy is not None:
@@ -216,7 +216,7 @@ class network(object):
         Adds an authority to pass-through the local proxies.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'authority': authority, 'apikey': apikey}
+        params = {'authority': authority}
         if enabled is not None:
             params['enabled'] = enabled
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/addPassThrough/', params)))
@@ -226,63 +226,63 @@ class network(object):
         Removes an alias.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/removeAlias/', {'name': name, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/removeAlias/', {'name': name})))
 
     def remove_local_server(self, address, port, apikey=''):
         """
         Removes a local server/proxy.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/removeLocalServer/', {'address': address, 'port': port, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/removeLocalServer/', {'address': address, 'port': port})))
 
     def remove_pass_through(self, authority, apikey=''):
         """
         Removes a pass-through.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/removePassThrough/', {'authority': authority, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/removePassThrough/', {'authority': authority})))
 
     def set_alias_enabled(self, name, enabled, apikey=''):
         """
         Sets whether or not an alias is enabled.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setAliasEnabled/', {'name': name, 'enabled': enabled, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setAliasEnabled/', {'name': name, 'enabled': enabled})))
 
     def set_pass_through_enabled(self, authority, enabled, apikey=''):
         """
         Sets whether or not a pass-through is enabled.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setPassThroughEnabled/', {'authority': authority, 'enabled': enabled, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setPassThroughEnabled/', {'authority': authority, 'enabled': enabled})))
 
     def set_connection_timeout(self, timeout, apikey=''):
         """
         Sets the timeout, for reads and connects.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setConnectionTimeout/', {'timeout': timeout, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setConnectionTimeout/', {'timeout': timeout})))
 
     def set_default_user_agent(self, useragent, apikey=''):
         """
         Sets the default user-agent.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setDefaultUserAgent/', {'userAgent': useragent, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setDefaultUserAgent/', {'userAgent': useragent})))
 
     def set_dns_ttl_successful_queries(self, ttl, apikey=''):
         """
         Sets the TTL of successful DNS queries.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setDnsTtlSuccessfulQueries/', {'ttl': ttl, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setDnsTtlSuccessfulQueries/', {'ttl': ttl})))
 
     def add_http_proxy_exclusion(self, host, enabled=None, apikey=''):
         """
         Adds a host to be excluded from the HTTP proxy.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'host': host, 'apikey': apikey}
+        params = {'host': host}
         if enabled is not None:
             params['enabled'] = enabled
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/addHttpProxyExclusion/', params)))
@@ -292,14 +292,14 @@ class network(object):
         Removes an HTTP proxy exclusion.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/removeHttpProxyExclusion/', {'host': host, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/removeHttpProxyExclusion/', {'host': host})))
 
     def set_http_proxy(self, host, port, realm=None, username=None, password=None, apikey=''):
         """
         Sets the HTTP proxy configuration.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'host': host, 'port': port, 'apikey': apikey}
+        params = {'host': host, 'port': port}
         if realm is not None:
             params['realm'] = realm
         if username is not None:
@@ -313,28 +313,28 @@ class network(object):
         Sets whether or not the HTTP proxy authentication is enabled.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setHttpProxyAuthEnabled/', {'enabled': enabled, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setHttpProxyAuthEnabled/', {'enabled': enabled})))
 
     def set_http_proxy_enabled(self, enabled, apikey=''):
         """
         Sets whether or not the HTTP proxy is enabled.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setHttpProxyEnabled/', {'enabled': enabled, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setHttpProxyEnabled/', {'enabled': enabled})))
 
     def set_http_proxy_exclusion_enabled(self, host, enabled, apikey=''):
         """
         Sets whether or not an HTTP proxy exclusion is enabled.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setHttpProxyExclusionEnabled/', {'host': host, 'enabled': enabled, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setHttpProxyExclusionEnabled/', {'host': host, 'enabled': enabled})))
 
     def set_socks_proxy(self, host, port, version=None, usedns=None, username=None, password=None, apikey=''):
         """
         Sets the SOCKS proxy configuration.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'host': host, 'port': port, 'apikey': apikey}
+        params = {'host': host, 'port': port}
         if version is not None:
             params['version'] = version
         if usedns is not None:
@@ -350,21 +350,21 @@ class network(object):
         Sets whether or not the SOCKS proxy is enabled.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setSocksProxyEnabled/', {'enabled': enabled, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setSocksProxyEnabled/', {'enabled': enabled})))
 
     def set_use_global_http_state(self, use, apikey=''):
         """
         Sets whether or not to use the global HTTP state.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setUseGlobalHttpState/', {'use': use, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setUseGlobalHttpState/', {'use': use})))
 
     def add_pkcs_12_client_certificate(self, filepath, password, index=None, apikey=''):
         """
         Adds a client certificate contained in a PKCS#12 file, the certificate is automatically set as active and used.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'filePath': filepath, 'password': password, 'apikey': apikey}
+        params = {'filePath': filepath, 'password': password}
         if index is not None:
             params['index'] = index
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/addPkcs12ClientCertificate/', params)))
@@ -374,46 +374,46 @@ class network(object):
         Sets whether or not to use the active client certificate.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setUseClientCertificate/', {'use': use, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setUseClientCertificate/', {'use': use})))
 
     def add_rate_limit_rule(self, description, enabled, matchregex, matchstring, requestspersecond, groupby, apikey=''):
         """
         Adds a rate limit rule
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/addRateLimitRule/', {'description': description, 'enabled': enabled, 'matchRegex': matchregex, 'matchString': matchstring, 'requestsPerSecond': requestspersecond, 'groupBy': groupby, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/addRateLimitRule/', {'description': description, 'enabled': enabled, 'matchRegex': matchregex, 'matchString': matchstring, 'requestsPerSecond': requestspersecond, 'groupBy': groupby})))
 
     def remove_rate_limit_rule(self, description, apikey=''):
         """
         Remove a rate limit rule
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/removeRateLimitRule/', {'description': description, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/removeRateLimitRule/', {'description': description})))
 
     def set_rate_limit_rule_enabled(self, description, enabled, apikey=''):
         """
         Set enabled state for a rate limit rule.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setRateLimitRuleEnabled/', {'description': description, 'enabled': enabled, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'network/action/setRateLimitRuleEnabled/', {'description': description, 'enabled': enabled})))
 
     def proxy_pac(self, apikey=''):
         """
         Provides a PAC file, proxying through the main proxy.
         This component is optional and therefore the API will only work if it is installed
         """
-        return (self.zap._request_other(self.zap.base_other + 'network/other/proxy.pac/', {'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'network/other/proxy.pac/', {}))
 
     def set_proxy(self, proxy, apikey=''):
         """
         Sets the HTTP proxy configuration.
         This component is optional and therefore the API will only work if it is installed
         """
-        return (self.zap._request_other(self.zap.base_other + 'network/other/setProxy/', {'proxy': proxy, 'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'network/other/setProxy/', {'proxy': proxy}))
 
     def root_ca_cert(self, apikey=''):
         """
         Gets the Root CA certificate used to issue server certificates. Suitable to import into client applications (e.g. browsers).
         This component is optional and therefore the API will only work if it is installed
         """
-        return (self.zap._request_other(self.zap.base_other + 'network/other/rootCaCert/', {'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'network/other/rootCaCert/', {}))

--- a/src/zapv2/openapi.py
+++ b/src/zapv2/openapi.py
@@ -32,7 +32,7 @@ class openapi(object):
         Imports an OpenAPI definition from a local file.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'file': file, 'apikey': apikey}
+        params = {'file': file}
         if target is not None:
             params['target'] = target
         if contextid is not None:
@@ -44,7 +44,7 @@ class openapi(object):
         Imports an OpenAPI definition from a URL.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'url': url, 'apikey': apikey}
+        params = {'url': url}
         if hostoverride is not None:
             params['hostOverride'] = hostoverride
         if contextid is not None:

--- a/src/zapv2/pnh.py
+++ b/src/zapv2/pnh.py
@@ -31,46 +31,46 @@ class pnh(object):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pnh/action/monitor/', {'id': id, 'message': message, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pnh/action/monitor/', {'id': id, 'message': message})))
 
     def oracle(self, id, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pnh/action/oracle/', {'id': id, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pnh/action/oracle/', {'id': id})))
 
     def start_monitoring(self, url, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pnh/action/startMonitoring/', {'url': url, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pnh/action/startMonitoring/', {'url': url})))
 
     def stop_monitoring(self, id, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pnh/action/stopMonitoring/', {'id': id, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pnh/action/stopMonitoring/', {'id': id})))
 
     def pnh(self, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return (self.zap._request_other(self.zap.base_other + 'pnh/other/pnh/', {'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'pnh/other/pnh/', {}))
 
     def manifest(self, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return (self.zap._request_other(self.zap.base_other + 'pnh/other/manifest/', {'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'pnh/other/manifest/', {}))
 
     def service(self, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return (self.zap._request_other(self.zap.base_other + 'pnh/other/service/', {'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'pnh/other/service/', {}))
 
     def fx__pnh_xpi(self, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return (self.zap._request_other(self.zap.base_other + 'pnh/other/fx_pnh.xpi/', {'apikey': apikey}))
+        return (self.zap._request_other(self.zap.base_other + 'pnh/other/fx_pnh.xpi/', {}))

--- a/src/zapv2/pscan.py
+++ b/src/zapv2/pscan.py
@@ -73,64 +73,64 @@ class pscan(object):
         """
         Sets whether or not the passive scanning is enabled (Note: the enabled state is not persisted).
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/setEnabled/', {'enabled': enabled, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/setEnabled/', {'enabled': enabled})))
 
     def set_scan_only_in_scope(self, onlyinscope, apikey=''):
         """
         Sets whether or not the passive scan should be performed only on messages that are in scope.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/setScanOnlyInScope/', {'onlyInScope': onlyinscope, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/setScanOnlyInScope/', {'onlyInScope': onlyinscope})))
 
     def enable_all_scanners(self, apikey=''):
         """
         Enables all passive scan rules
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/enableAllScanners/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/enableAllScanners/', {})))
 
     def disable_all_scanners(self, apikey=''):
         """
         Disables all passive scan rules
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/disableAllScanners/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/disableAllScanners/', {})))
 
     def enable_scanners(self, ids, apikey=''):
         """
         Enables all passive scan rules with the given IDs (comma separated list of IDs)
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/enableScanners/', {'ids': ids, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/enableScanners/', {'ids': ids})))
 
     def disable_scanners(self, ids, apikey=''):
         """
         Disables all passive scan rules with the given IDs (comma separated list of IDs)
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/disableScanners/', {'ids': ids, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/disableScanners/', {'ids': ids})))
 
     def set_scanner_alert_threshold(self, id, alertthreshold, apikey=''):
         """
         Sets the alert threshold of the passive scan rule with the given ID, accepted values for alert threshold: OFF, DEFAULT, LOW, MEDIUM and HIGH
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/setScannerAlertThreshold/', {'id': id, 'alertThreshold': alertthreshold, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/setScannerAlertThreshold/', {'id': id, 'alertThreshold': alertthreshold})))
 
     def set_max_alerts_per_rule(self, maxalerts, apikey=''):
         """
         Sets the maximum number of alerts a passive scan rule should raise.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/setMaxAlertsPerRule/', {'maxAlerts': maxalerts, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/setMaxAlertsPerRule/', {'maxAlerts': maxalerts})))
 
     def disable_all_tags(self, apikey=''):
         """
         Disables all passive scan tags.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/disableAllTags/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/disableAllTags/', {})))
 
     def enable_all_tags(self, apikey=''):
         """
         Enables all passive scan tags.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/enableAllTags/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/enableAllTags/', {})))
 
     def clear_queue(self, apikey=''):
         """
         Clears the passive scan queue.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/clearQueue/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'pscan/action/clearQueue/', {})))

--- a/src/zapv2/replacer.py
+++ b/src/zapv2/replacer.py
@@ -40,7 +40,7 @@ class replacer(object):
         Adds a replacer rule. For the parameters: desc is a user friendly description, enabled is true or false, matchType is one of [REQ_HEADER, REQ_HEADER_STR, REQ_BODY_STR, RESP_HEADER, RESP_HEADER_STR, RESP_BODY_STR], matchRegex should be true if the matchString should be treated as a regex otherwise false, matchString is the string that will be matched against, replacement is the replacement string, initiators may be blank (for all initiators) or a comma separated list of integers as defined in <a href="https://github.com/zaproxy/zaproxy/blob/main/zap/src/main/java/org/parosproxy/paros/network/HttpSender.java">HttpSender</a>  
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'description': description, 'enabled': enabled, 'matchType': matchtype, 'matchRegex': matchregex, 'matchString': matchstring, 'apikey': apikey}
+        params = {'description': description, 'enabled': enabled, 'matchType': matchtype, 'matchRegex': matchregex, 'matchString': matchstring}
         if replacement is not None:
             params['replacement'] = replacement
         if initiators is not None:
@@ -54,11 +54,11 @@ class replacer(object):
         Removes the rule with the given description
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'replacer/action/removeRule/', {'description': description, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'replacer/action/removeRule/', {'description': description})))
 
     def set_enabled(self, description, bool, apikey=''):
         """
         Enables or disables the rule with the given description based on the bool parameter  
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'replacer/action/setEnabled/', {'description': description, 'bool': bool, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'replacer/action/setEnabled/', {'description': description, 'bool': bool})))

--- a/src/zapv2/reports.py
+++ b/src/zapv2/reports.py
@@ -47,7 +47,7 @@ class reports(object):
         Generate a report with the supplied parameters.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'title': title, 'template': template, 'apikey': apikey}
+        params = {'title': title, 'template': template}
         if theme is not None:
             params['theme'] = theme
         if description is not None:

--- a/src/zapv2/retest.py
+++ b/src/zapv2/retest.py
@@ -31,4 +31,4 @@ class retest(object):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'retest/action/retest/', {'alertIds': alertids, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'retest/action/retest/', {'alertIds': alertids})))

--- a/src/zapv2/reveal.py
+++ b/src/zapv2/reveal.py
@@ -40,4 +40,4 @@ class reveal(object):
         Sets if shows hidden fields and enables disabled fields
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'reveal/action/setReveal/', {'reveal': reveal, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'reveal/action/setReveal/', {'reveal': reveal})))

--- a/src/zapv2/revisit.py
+++ b/src/zapv2/revisit.py
@@ -38,10 +38,10 @@ class revisit(object):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'revisit/action/revisitSiteOn/', {'site': site, 'startTime': starttime, 'endTime': endtime, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'revisit/action/revisitSiteOn/', {'site': site, 'startTime': starttime, 'endTime': endtime})))
 
     def revisit_site_off(self, site, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'revisit/action/revisitSiteOff/', {'site': site, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'revisit/action/revisitSiteOff/', {'site': site})))

--- a/src/zapv2/ruleConfig.py
+++ b/src/zapv2/ruleConfig.py
@@ -44,19 +44,19 @@ class ruleConfig(object):
         """
         Reset the specified rule configuration, which must already exist
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ruleConfig/action/resetRuleConfigValue/', {'key': key, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ruleConfig/action/resetRuleConfigValue/', {'key': key})))
 
     def reset_all_rule_config_values(self, apikey=''):
         """
         Reset all of the rule configurations
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ruleConfig/action/resetAllRuleConfigValues/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'ruleConfig/action/resetAllRuleConfigValues/', {})))
 
     def set_rule_config_value(self, key, value=None, apikey=''):
         """
         Set the specified rule configuration, which must already exist
         """
-        params = {'key': key, 'apikey': apikey}
+        params = {'key': key}
         if value is not None:
             params['value'] = value
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'ruleConfig/action/setRuleConfigValue/', params)))

--- a/src/zapv2/script.py
+++ b/src/zapv2/script.py
@@ -102,19 +102,19 @@ class script(object):
         """
         Enables the script with the given name
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/enable/', {'scriptName': scriptname, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/enable/', {'scriptName': scriptname})))
 
     def disable(self, scriptname, apikey=''):
         """
         Disables the script with the given name
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/disable/', {'scriptName': scriptname, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/disable/', {'scriptName': scriptname})))
 
     def load(self, scriptname, scripttype, scriptengine, filename, scriptdescription=None, charset=None, apikey=''):
         """
         Loads a script into ZAP from the given local file, with the given name, type and engine, optionally with a description, and a charset name to read the script (the charset name is required if the script is not in UTF-8, for example, in ISO-8859-1).
         """
-        params = {'scriptName': scriptname, 'scriptType': scripttype, 'scriptEngine': scriptengine, 'fileName': filename, 'apikey': apikey}
+        params = {'scriptName': scriptname, 'scriptType': scripttype, 'scriptEngine': scriptengine, 'fileName': filename}
         if scriptdescription is not None:
             params['scriptDescription'] = scriptdescription
         if charset is not None:
@@ -125,55 +125,55 @@ class script(object):
         """
         Removes the script with the given name
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/remove/', {'scriptName': scriptname, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/remove/', {'scriptName': scriptname})))
 
     def run_stand_alone_script(self, scriptname, apikey=''):
         """
         Runs the stand alone script with the given name
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/runStandAloneScript/', {'scriptName': scriptname, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/runStandAloneScript/', {'scriptName': scriptname})))
 
     def clear_global_var(self, varkey, apikey=''):
         """
         Clears the global variable with the given key.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/clearGlobalVar/', {'varKey': varkey, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/clearGlobalVar/', {'varKey': varkey})))
 
     def clear_global_custom_var(self, varkey, apikey=''):
         """
         Clears a global custom variable.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/clearGlobalCustomVar/', {'varKey': varkey, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/clearGlobalCustomVar/', {'varKey': varkey})))
 
     def clear_global_vars(self, apikey=''):
         """
         Clears the global variables.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/clearGlobalVars/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/clearGlobalVars/', {})))
 
     def clear_script_var(self, scriptname, varkey, apikey=''):
         """
         Clears the variable with the given key of the given script. Returns an API error (DOES_NOT_EXIST) if no script with the given name exists.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/clearScriptVar/', {'scriptName': scriptname, 'varKey': varkey, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/clearScriptVar/', {'scriptName': scriptname, 'varKey': varkey})))
 
     def clear_script_custom_var(self, scriptname, varkey, apikey=''):
         """
         Clears a script custom variable.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/clearScriptCustomVar/', {'scriptName': scriptname, 'varKey': varkey, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/clearScriptCustomVar/', {'scriptName': scriptname, 'varKey': varkey})))
 
     def clear_script_vars(self, scriptname, apikey=''):
         """
         Clears the variables of the given script. Returns an API error (DOES_NOT_EXIST) if no script with the given name exists.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/clearScriptVars/', {'scriptName': scriptname, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/clearScriptVars/', {'scriptName': scriptname})))
 
     def set_script_var(self, scriptname, varkey, varvalue=None, apikey=''):
         """
         Sets the value of the variable with the given key of the given script. Returns an API error (DOES_NOT_EXIST) if no script with the given name exists.
         """
-        params = {'scriptName': scriptname, 'varKey': varkey, 'apikey': apikey}
+        params = {'scriptName': scriptname, 'varKey': varkey}
         if varvalue is not None:
             params['varValue'] = varvalue
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/setScriptVar/', params)))
@@ -182,7 +182,7 @@ class script(object):
         """
         Sets the value of the global variable with the given key.
         """
-        params = {'varKey': varkey, 'apikey': apikey}
+        params = {'varKey': varkey}
         if varvalue is not None:
             params['varValue'] = varvalue
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'script/action/setGlobalVar/', params)))

--- a/src/zapv2/search.py
+++ b/src/zapv2/search.py
@@ -135,7 +135,7 @@ class search(object):
         """
         Returns the HTTP messages, in HAR format, that match the given regular expression in the URL optionally filtered by URL and paginated with 'start' position and 'count' of messages.
         """
-        params = {'regex': regex, 'apikey': apikey}
+        params = {'regex': regex}
         if baseurl is not None:
             params['baseurl'] = baseurl
         if start is not None:
@@ -148,7 +148,7 @@ class search(object):
         """
         Returns the HTTP messages, in HAR format, that match the given regular expression in the request optionally filtered by URL and paginated with 'start' position and 'count' of messages.
         """
-        params = {'regex': regex, 'apikey': apikey}
+        params = {'regex': regex}
         if baseurl is not None:
             params['baseurl'] = baseurl
         if start is not None:
@@ -161,7 +161,7 @@ class search(object):
         """
         Returns the HTTP messages, in HAR format, that match the given regular expression in the response optionally filtered by URL and paginated with 'start' position and 'count' of messages.
         """
-        params = {'regex': regex, 'apikey': apikey}
+        params = {'regex': regex}
         if baseurl is not None:
             params['baseurl'] = baseurl
         if start is not None:
@@ -174,7 +174,7 @@ class search(object):
         """
         Returns the HTTP messages, in HAR format, that match the given regular expression in the header(s) optionally filtered by URL and paginated with 'start' position and 'count' of messages.
         """
-        params = {'regex': regex, 'apikey': apikey}
+        params = {'regex': regex}
         if baseurl is not None:
             params['baseurl'] = baseurl
         if start is not None:

--- a/src/zapv2/selenium.py
+++ b/src/zapv2/selenium.py
@@ -92,43 +92,43 @@ class selenium(object):
         Sets the current path to Chrome binary
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionChromeBinaryPath/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionChromeBinaryPath/', {'String': string})))
 
     def set_option_chrome_driver_path(self, string, apikey=''):
         """
         Sets the current path to ChromeDriver
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionChromeDriverPath/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionChromeDriverPath/', {'String': string})))
 
     def set_option_firefox_binary_path(self, string, apikey=''):
         """
         Sets the current path to Firefox binary
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionFirefoxBinaryPath/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionFirefoxBinaryPath/', {'String': string})))
 
     def set_option_firefox_driver_path(self, string, apikey=''):
         """
         Sets the current path to Firefox driver (geckodriver)
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionFirefoxDriverPath/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionFirefoxDriverPath/', {'String': string})))
 
     def set_option_ie_driver_path(self, string, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionIeDriverPath/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionIeDriverPath/', {'String': string})))
 
     def set_option_last_directory(self, string, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionLastDirectory/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionLastDirectory/', {'String': string})))
 
     def set_option_phantom_js_binary_path(self, string, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionPhantomJsBinaryPath/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'selenium/action/setOptionPhantomJsBinaryPath/', {'String': string})))

--- a/src/zapv2/sessionManagement.py
+++ b/src/zapv2/sessionManagement.py
@@ -50,7 +50,7 @@ class sessionManagement(object):
         """
         Sets the session management method for the context with the given ID.
         """
-        params = {'contextId': contextid, 'methodName': methodname, 'apikey': apikey}
+        params = {'contextId': contextid, 'methodName': methodname}
         if methodconfigparams is not None:
             params['methodConfigParams'] = methodconfigparams
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'sessionManagement/action/setSessionManagementMethod/', params)))

--- a/src/zapv2/soap.py
+++ b/src/zapv2/soap.py
@@ -32,11 +32,11 @@ class soap(object):
         Import a WSDL definition from local file.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'soap/action/importFile/', {'file': file, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'soap/action/importFile/', {'file': file})))
 
     def import_url(self, url, apikey=''):
         """
         Import a WSDL definition from a URL.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'soap/action/importUrl/', {'url': url, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'soap/action/importUrl/', {'url': url})))

--- a/src/zapv2/spider.py
+++ b/src/zapv2/spider.py
@@ -292,7 +292,7 @@ class spider(object):
         Runs the spider against the given URL (or context). Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, the 'recurse' parameter can be used to prevent the spider from seeding recursively, the parameter 'contextName' can be used to constrain the scan to a Context and the parameter 'subtreeOnly' allows to restrict the spider under a site's subtree (using the specified 'url').
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'apikey': apikey}
+        params = {}
         if url is not None:
             params['url'] = url
         if maxchildren is not None:
@@ -310,7 +310,7 @@ class spider(object):
         Runs the spider from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'contextId': contextid, 'userId': userid, 'apikey': apikey}
+        params = {'contextId': contextid, 'userId': userid}
         if url is not None:
             params['url'] = url
         if maxchildren is not None:
@@ -326,21 +326,21 @@ class spider(object):
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/pause/', {'scanId': scanid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/pause/', {'scanId': scanid})))
 
     def resume(self, scanid, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/resume/', {'scanId': scanid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/resume/', {'scanId': scanid})))
 
     def stop(self, scanid=None, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'apikey': apikey}
+        params = {}
         if scanid is not None:
             params['scanId'] = scanid
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/stop/', params)))
@@ -350,56 +350,56 @@ class spider(object):
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/removeScan/', {'scanId': scanid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/removeScan/', {'scanId': scanid})))
 
     def pause_all_scans(self, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/pauseAllScans/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/pauseAllScans/', {})))
 
     def resume_all_scans(self, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/resumeAllScans/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/resumeAllScans/', {})))
 
     def stop_all_scans(self, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/stopAllScans/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/stopAllScans/', {})))
 
     def remove_all_scans(self, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/removeAllScans/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/removeAllScans/', {})))
 
     def clear_excluded_from_scan(self, apikey=''):
         """
         Clears the regexes of URLs excluded from the spider scans.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/clearExcludedFromScan/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/clearExcludedFromScan/', {})))
 
     def exclude_from_scan(self, regex, apikey=''):
         """
         Adds a regex of URLs that should be excluded from the spider scans.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/excludeFromScan/', {'regex': regex, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/excludeFromScan/', {'regex': regex})))
 
     def add_domain_always_in_scope(self, value, isregex=None, isenabled=None, apikey=''):
         """
         Adds a new domain that's always in scope, using the specified value. Optionally sets if the new entry is enabled (default, true) and whether or not the new value is specified as a regex (default, false).
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'value': value, 'apikey': apikey}
+        params = {'value': value}
         if isregex is not None:
             params['isRegex'] = isregex
         if isenabled is not None:
@@ -411,7 +411,7 @@ class spider(object):
         Modifies a domain that's always in scope. Allows to modify the value, if enabled or if a regex. The domain is selected with its index, which can be obtained with the view domainsAlwaysInScope.
         This component is optional and therefore the API will only work if it is installed
         """
-        params = {'idx': idx, 'apikey': apikey}
+        params = {'idx': idx}
         if value is not None:
             params['value'] = value
         if isregex is not None:
@@ -425,171 +425,171 @@ class spider(object):
         Removes a domain that's always in scope, with the given index. The index can be obtained with the view domainsAlwaysInScope.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/removeDomainAlwaysInScope/', {'idx': idx, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/removeDomainAlwaysInScope/', {'idx': idx})))
 
     def enable_all_domains_always_in_scope(self, apikey=''):
         """
         Enables all domains that are always in scope.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/enableAllDomainsAlwaysInScope/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/enableAllDomainsAlwaysInScope/', {})))
 
     def disable_all_domains_always_in_scope(self, apikey=''):
         """
         Disables all domains that are always in scope.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/disableAllDomainsAlwaysInScope/', {'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/disableAllDomainsAlwaysInScope/', {})))
 
     def set_option_handle_parameters(self, string, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionHandleParameters/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionHandleParameters/', {'String': string})))
 
     def set_option_skip_url_string(self, string, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionSkipURLString/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionSkipURLString/', {'String': string})))
 
     def set_option_user_agent(self, string, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionUserAgent/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionUserAgent/', {'String': string})))
 
     def set_option_accept_cookies(self, boolean, apikey=''):
         """
         Sets whether or not a spider process should accept cookies while spidering.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionAcceptCookies/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionAcceptCookies/', {'Boolean': boolean})))
 
     def set_option_handle_o_data_parameters_visited(self, boolean, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionHandleODataParametersVisited/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionHandleODataParametersVisited/', {'Boolean': boolean})))
 
     def set_option_max_children(self, integer, apikey=''):
         """
         Sets the maximum number of child nodes (per node) that can be crawled, 0 means no limit.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxChildren/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxChildren/', {'Integer': integer})))
 
     def set_option_max_depth(self, integer, apikey=''):
         """
         Sets the maximum depth the spider can crawl, 0 for unlimited depth.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxDepth/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxDepth/', {'Integer': integer})))
 
     def set_option_max_duration(self, integer, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxDuration/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxDuration/', {'Integer': integer})))
 
     def set_option_max_parse_size_bytes(self, integer, apikey=''):
         """
         Sets the maximum size, in bytes, that a response might have to be parsed. This allows the spider to skip big responses/files.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxParseSizeBytes/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxParseSizeBytes/', {'Integer': integer})))
 
     def set_option_max_scans_in_ui(self, integer, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxScansInUI/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionMaxScansInUI/', {'Integer': integer})))
 
     def set_option_parse_comments(self, boolean, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseComments/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseComments/', {'Boolean': boolean})))
 
     def set_option_parse_ds_store(self, boolean, apikey=''):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseDsStore/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseDsStore/', {'Boolean': boolean})))
 
     def set_option_parse_git(self, boolean, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseGit/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseGit/', {'Boolean': boolean})))
 
     def set_option_parse_robots_txt(self, boolean, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseRobotsTxt/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseRobotsTxt/', {'Boolean': boolean})))
 
     def set_option_parse_svn_entries(self, boolean, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseSVNEntries/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseSVNEntries/', {'Boolean': boolean})))
 
     def set_option_parse_sitemap_xml(self, boolean, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseSitemapXml/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionParseSitemapXml/', {'Boolean': boolean})))
 
     def set_option_post_form(self, boolean, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionPostForm/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionPostForm/', {'Boolean': boolean})))
 
     def set_option_process_form(self, boolean, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionProcessForm/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionProcessForm/', {'Boolean': boolean})))
 
     def set_option_request_wait_time(self, integer, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionRequestWaitTime/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionRequestWaitTime/', {'Integer': integer})))
 
     def set_option_send_referer_header(self, boolean, apikey=''):
         """
         Sets whether or not the 'Referer' header should be sent while spidering.
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionSendRefererHeader/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionSendRefererHeader/', {'Boolean': boolean})))
 
     def set_option_show_advanced_dialog(self, boolean, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionShowAdvancedDialog/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionShowAdvancedDialog/', {'Boolean': boolean})))
 
     def set_option_thread_count(self, integer, apikey=''):
         """
         
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionThreadCount/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'spider/action/setOptionThreadCount/', {'Integer': integer})))

--- a/src/zapv2/stats.py
+++ b/src/zapv2/stats.py
@@ -93,7 +93,7 @@ class stats(object):
         """
         Clears all of the statistics
         """
-        params = {'apikey': apikey}
+        params = {}
         if keyprefix is not None:
             params['keyPrefix'] = keyprefix
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'stats/action/clearStats/', params)))
@@ -102,22 +102,22 @@ class stats(object):
         """
         Sets the Statsd service hostname, supply an empty string to stop using a Statsd service
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'stats/action/setOptionStatsdHost/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'stats/action/setOptionStatsdHost/', {'String': string})))
 
     def set_option_statsd_prefix(self, string, apikey=''):
         """
         Sets the prefix to be applied to all stats sent to the configured Statsd service
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'stats/action/setOptionStatsdPrefix/', {'String': string, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'stats/action/setOptionStatsdPrefix/', {'String': string})))
 
     def set_option_in_memory_enabled(self, boolean, apikey=''):
         """
         Sets whether in memory statistics are enabled
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'stats/action/setOptionInMemoryEnabled/', {'Boolean': boolean, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'stats/action/setOptionInMemoryEnabled/', {'Boolean': boolean})))
 
     def set_option_statsd_port(self, integer, apikey=''):
         """
         Sets the Statsd service port
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'stats/action/setOptionStatsdPort/', {'Integer': integer, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'stats/action/setOptionStatsdPort/', {'Integer': integer})))

--- a/src/zapv2/users.py
+++ b/src/zapv2/users.py
@@ -70,31 +70,31 @@ class users(object):
         """
         Creates a new user with the given name for the context with the given ID.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/newUser/', {'contextId': contextid, 'name': name, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/newUser/', {'contextId': contextid, 'name': name})))
 
     def remove_user(self, contextid, userid, apikey=''):
         """
         Removes the user with the given ID that belongs to the context with the given ID.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/removeUser/', {'contextId': contextid, 'userId': userid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/removeUser/', {'contextId': contextid, 'userId': userid})))
 
     def set_user_enabled(self, contextid, userid, enabled, apikey=''):
         """
         Sets whether or not the user, with the given ID that belongs to the context with the given ID, should be enabled.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/setUserEnabled/', {'contextId': contextid, 'userId': userid, 'enabled': enabled, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/setUserEnabled/', {'contextId': contextid, 'userId': userid, 'enabled': enabled})))
 
     def set_user_name(self, contextid, userid, name, apikey=''):
         """
         Renames the user with the given ID that belongs to the context with the given ID.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/setUserName/', {'contextId': contextid, 'userId': userid, 'name': name, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/setUserName/', {'contextId': contextid, 'userId': userid, 'name': name})))
 
     def set_authentication_credentials(self, contextid, userid, authcredentialsconfigparams=None, apikey=''):
         """
         Sets the authentication credentials for the user with the given ID that belongs to the context with the given ID.
         """
-        params = {'contextId': contextid, 'userId': userid, 'apikey': apikey}
+        params = {'contextId': contextid, 'userId': userid}
         if authcredentialsconfigparams is not None:
             params['authCredentialsConfigParams'] = authcredentialsconfigparams
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/setAuthenticationCredentials/', params)))
@@ -103,19 +103,19 @@ class users(object):
         """
         Tries to authenticate as the identified user, returning the authentication request and whether it appears to have succeeded.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/authenticateAsUser/', {'contextId': contextid, 'userId': userid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/authenticateAsUser/', {'contextId': contextid, 'userId': userid})))
 
     def poll_as_user(self, contextid, userid, apikey=''):
         """
         Tries to poll as the identified user, returning the authentication request and whether it appears to have succeeded. This will only work if the polling verification strategy has been configured.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/pollAsUser/', {'contextId': contextid, 'userId': userid, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/action/pollAsUser/', {'contextId': contextid, 'userId': userid})))
 
     def set_authentication_state(self, contextid, userid, lastpollresult=None, lastpolltimeinms=None, requestssincelastpoll=None, apikey=''):
         """
         Sets fields in the authentication state for the user identified by the Context and User Ids.
         """
-        params = {'contextId': contextid, 'userId': userid, 'apikey': apikey}
+        params = {'contextId': contextid, 'userId': userid}
         if lastpollresult is not None:
             params['lastPollResult'] = lastpollresult
         if lastpolltimeinms is not None:
@@ -128,7 +128,7 @@ class users(object):
         """
         Sets the specified cookie for the user identified by the Context and User Ids.
         """
-        params = {'contextId': contextid, 'userId': userid, 'domain': domain, 'name': name, 'value': value, 'apikey': apikey}
+        params = {'contextId': contextid, 'userId': userid, 'domain': domain, 'name': name, 'value': value}
         if path is not None:
             params['path'] = path
         if secure is not None:

--- a/src/zapv2/websocket.py
+++ b/src/zapv2/websocket.py
@@ -71,11 +71,11 @@ class websocket(object):
         Sends the specified message on the channel specified by channelId, if outgoing is 'True' then the message will be sent to the server and if it is 'False' then it will be sent to the client
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'websocket/action/sendTextMessage/', {'channelId': channelid, 'outgoing': outgoing, 'message': message, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'websocket/action/sendTextMessage/', {'channelId': channelid, 'outgoing': outgoing, 'message': message})))
 
     def set_break_text_message(self, message, outgoing, apikey=''):
         """
         Sets the text message for an intercepted websockets message
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'websocket/action/setBreakTextMessage/', {'message': message, 'outgoing': outgoing, 'apikey': apikey})))
+        return six.next(six.itervalues(self.zap._request(self.zap.base + 'websocket/action/setBreakTextMessage/', {'message': message, 'outgoing': outgoing})))

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -14,7 +14,7 @@ TEST_PROXIES = {
 def assert_api_key(response, apikey='testapikey'):
     """Some requests should contain valid ZAP api key."""
     assert response._request.headers['X-ZAP-API-Key'] == apikey
-    assert 'apikey=%s' % apikey in response.query
+    assert 'apikey=%s' % apikey not in response.query
 
 
 def test_urlopen(zap, client_mock):


### PR DESCRIPTION
Stop using the `apikey` parameter provided in the functions as that was superseded by the API key set when the client is created (which is sent as an HTTP header).
Update APIs of add-ons and core, using the latest Python API generator.

Related to zaproxy/zaproxy#8143.