### PR TITLE
Do not unwrap `get_user_by_id`'s response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Return the whole response from `users.get_user_by_id`.
 
 ## [0.2.0] - 2023-11-03
 ### Changed

--- a/src/zapv2/users.py
+++ b/src/zapv2/users.py
@@ -40,7 +40,7 @@ class users(object):
         """
         Gets the data of the user with the given ID that belongs to the context with the given ID.
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'users/view/getUserById/', {'contextId': contextid, 'userId': userid})))
+        return (self.zap._request(self.zap.base + 'users/view/getUserById/', {'contextId': contextid, 'userId': userid}))
 
     def get_authentication_credentials_config_params(self, contextid):
         """


### PR DESCRIPTION
Return the response directly as it's not wrapped in an object.

Part of zaproxy/zaproxy#8282.