### PR TITLE
Add workflow to release to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release PyPI
+
+on:
+  push:
+    tags:
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/zaproxy
+    permissions:
+      id-token: write
+    steps:
+    - run: poetry build
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,14 +9,5 @@ Tag (and push) the new version:
     git tag -s 0.0.X -m "Version 0.0.X."
     git push upstream 0.0.X
 
-(Checkout the tag and ensure the working copy is clean.)
-
-Build the distribution (source and wheel) files:
-
-     poetry build
-
-Upload to PyPi:
-
-     poetry publish
-
-The user must have permissions to upload to the `zaproxy` package.
+The workflow [Release PyPI](https://github.com/zaproxy/zap-api-python/blob/main/.github/workflows/release.yml)
+will be triggered by the tag push and release to PyPI.


### PR DESCRIPTION
Add workflow to automatically release to PyPI when the tag is pushed.