### PR TITLE
Fix issues in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release PyPI
 on:
   push:
     tags:
+      - '*'
 
 jobs:
   pypi-publish:
@@ -14,6 +15,13 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - run: poetry build
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - run: |
+        python -m pip install --upgrade pip
+        pipx install poetry==1.7.0
+        poetry build
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Make sure to checkout the repo and install poetry before trying to build and release.
Correct syntax to only run on tag push.