### PR TITLE
Restructure docs to use README as long desc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to zap-api-python
+
+## Updating the Generated Files
+
+Most of the API code is generated from the ZAP java source code.
+
+To regenerate the API code you will need the repos [zaproxy](https://github.com/zaproxy/zaproxy) and [zap-extensions](https://github.com/zaproxy/zap-extensions) checked out at the same level as this one.
+
+You should typically generate the core API calls from the latest release tag e.g.:
+
+```
+cd zaproxy
+git fetch upstream -t
+git checkout tags/v2.13.0
+./gradlew generatePythonApiEndpoints
+cd ..
+```
+
+The add-on APIs can be generated from the zap-extensions `main` branch:
+
+```
+cd zap-extensions
+git pull upstream main
+./gradle generatePythonZapApiClientFiles --continue
+cd ..
+```
+
+The above commands will update the files in `src/zapv2`.
+
+If any new files are created then they should be manually added to `src/zapv2/__init__.py` as per the existing files.
+
+## Changelog
+
+Note that you should also update the `CHANGELOG.md` file to state whatever has been changed.

--- a/README.md
+++ b/README.md
@@ -22,34 +22,3 @@ For help using the ZAP API, refer to:
 ## Issues
 
 To report issues related to ZAP API, bugs and enhancements requests, use the [issue tracker of the main ZAP project](https://github.com/zaproxy/zaproxy/issues).
-
-## Updating the Generated Files
-
-Most of the API code is generated from the ZAP java source code.
-
-To regenerate the API code you will need the repos [zaproxy](https://github.com/zaproxy/zaproxy) and [zap-extensions](https://github.com/zaproxy/zap-extensions) checked out at the same level as this one.
-
-You should typically generate the core API calls from the latest release tag e.g.:
-
-```
-cd zaproxy
-git fetch upstream -t
-git checkout tags/v2.13.0
-./gradlew generatePythonApiEndpoints
-cd ..
-```
-
-The add-on APIs can be generated from the zap-extensions `main` branch:
-
-```
-cd zap-extensions
-git pull upstream main
-./gradle generatePythonZapApiClientFiles --continue
-cd ..
-```
-
-The above commands will update the files in `src/zapv2`.
-
-If any new files are created then they should be manually added to `src/zapv2/__init__.py` as per the existing files.
-
-Note that you should also update the `CHANGELOG.md` file to state whatever has been changed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "zaproxy"
 # Ensure __version__ in src/zapv2/__init__.py matches.
 version = "0.3.0"
 description = "ZAP API Client"
+readme = "README.md"
 authors = ["ZAP Development Team <zaproxy-develop@googlegroups.com>"]
 license = "Apache-2.0"
 

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -38,6 +38,7 @@ from .autoupdate import autoupdate
 from .brk import brk
 from .context import context
 from .core import core
+from .custompayloads import custompayloads
 from .exim import exim
 from .forcedUser import forcedUser
 from .graphql import graphql
@@ -103,6 +104,7 @@ class ZAPv2(object):
         self.brk = brk(self)
         self.context = context(self)
         self.core = core(self)
+        self.custompayloads = custompayloads(self)
         self.exim = exim(self)
         self.forcedUser = forcedUser(self)
         self.graphql = graphql(self)


### PR DESCRIPTION
Move contributing guidelines to its own file to have the README just for usage information and be more suitable as long description of the project (show in PyPI website).
Also, include Custom Payloads in the API client, missed in previous change.

---
Release failed because of missing long desc:
> ERROR `long_description` has syntax errors in markup and would not be rendered on PyPI.
> No content rendered from RST source. 

https://github.com/zaproxy/zap-api-python/actions/runs/9021271433/job/24788221368#step:6:20