### PR TITLE
Do not unwrap `plan_progress`'s response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [0.3.1] - 2024-05-20
+### Fixed
+- Return the whole response from `automation.plan_progress`.
 
 ## [0.3.0] - 2024-05-09
 ### Added
@@ -173,7 +175,7 @@ ensure it's automatically sent in all API requests.
 ### Changed
 - Moved from the main `zaproxy` repository.
 
-[Unreleased]: https://github.com/zaproxy/zap-api-python/compare/0.3.0...HEAD
+[0.3.1]: https://github.com/zaproxy/zap-api-python/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/zaproxy/zap-api-python/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/zaproxy/zap-api-python/compare/0.1.1...0.2.0
 [0.1.1]: https://github.com/zaproxy/zap-api-python/compare/0.1.0...0.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "zaproxy"
 # Ensure __version__ in src/zapv2/__init__.py matches.
-version = "0.4.0"
+version = "0.3.1"
 description = "ZAP API Client"
 readme = "README.md"
 authors = ["ZAP Development Team <zaproxy-develop@googlegroups.com>"]

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -20,7 +20,7 @@ Client implementation for using the ZAP pentesting proxy remotely.
 """
 
 __docformat__ = 'restructuredtext'
-__version__ = '0.4.0'
+__version__ = '0.3.1'
 
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning

--- a/src/zapv2/automation.py
+++ b/src/zapv2/automation.py
@@ -31,7 +31,7 @@ class automation(object):
         """
         This component is optional and therefore the API will only work if it is installed
         """
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'automation/view/planProgress/', {'planId': planid})))
+        return (self.zap._request(self.zap.base + 'automation/view/planProgress/', {'planId': planid}))
 
     def run_plan(self, filepath, apikey=''):
         """


### PR DESCRIPTION
Return the response directly as it's not wrapped in an object.
Prepare release.

---
From ZAP User Group: https://groups.google.com/g/zaproxy-users/c/SXvHcCSADPc/m/ZTDibyhrBAAJ