### PR TITLE
Do not unwrap `stats`'s response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [0.3.2] - 2024-06-04
+### Fixed
+- Return the whole response from `stats.stats`.
 
 ## [0.3.1] - 2024-05-20
 ### Fixed
@@ -177,7 +179,7 @@ ensure it's automatically sent in all API requests.
 ### Changed
 - Moved from the main `zaproxy` repository.
 
-[Unreleased]: https://github.com/zaproxy/zap-api-python/compare/0.3.1...HEAD
+[0.3.2]: https://github.com/zaproxy/zap-api-python/compare/0.3.1...0.3.2
 [0.3.1]: https://github.com/zaproxy/zap-api-python/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/zaproxy/zap-api-python/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/zaproxy/zap-api-python/compare/0.1.1...0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "zaproxy"
 # Ensure __version__ in src/zapv2/__init__.py matches.
-version = "0.4.0"
+version = "0.3.2"
 description = "ZAP API Client"
 readme = "README.md"
 authors = ["ZAP Development Team <zaproxy-develop@googlegroups.com>"]

--- a/src/zapv2/__init__.py
+++ b/src/zapv2/__init__.py
@@ -20,7 +20,7 @@ Client implementation for using the ZAP pentesting proxy remotely.
 """
 
 __docformat__ = 'restructuredtext'
-__version__ = '0.4.0'
+__version__ = '0.3.2'
 
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning

--- a/src/zapv2/stats.py
+++ b/src/zapv2/stats.py
@@ -34,7 +34,7 @@ class stats(object):
         params = {}
         if keyprefix is not None:
             params['keyPrefix'] = keyprefix
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'stats/view/stats/', params)))
+        return (self.zap._request(self.zap.base + 'stats/view/stats/', params))
 
     def all_sites_stats(self, keyprefix=None):
         """


### PR DESCRIPTION
Return the response directly as it's not wrapped in an object.
Prepare release.