### PR TITLE
Add support for 'method' parameter in Replacer 'add_rule'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-04-24
+### Changed
+- Added support for 'method' parameter on Replacer 'add_rule'
+
 ## [0.5.0] - 2025-12-15
 ### Added
 - Add the APIs of the following add-ons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## [0.5.1] - 2026-04-24
 ### Changed
 - Added support for 'method' parameter on Replacer 'add_rule'
 

--- a/src/zapv2/replacer.py
+++ b/src/zapv2/replacer.py
@@ -2,7 +2,7 @@
 #
 # ZAP is an HTTP/HTTPS proxy for assessing web application security.
 #
-# Copyright 2025 the ZAP development team
+# Copyright 2026 the ZAP development team
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class replacer(object):
         """
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'replacer/view/rules/')))
 
-    def add_rule(self, description, enabled, matchtype, matchregex, matchstring, replacement=None, initiators=None, url=None, apikey=''):
+    def add_rule(self, description, enabled, matchtype, matchregex, matchstring, replacement=None, initiators=None, url=None, method=None, apikey=''):
         """
         Adds a replacer rule. For the parameters: desc is a user friendly description, enabled is true or false, matchType is one of [REQ_HEADER, REQ_HEADER_STR, REQ_BODY_STR, RESP_HEADER, RESP_HEADER_STR, RESP_BODY_STR], matchRegex should be true if the matchString should be treated as a regex otherwise false, matchString is the string that will be matched against, replacement is the replacement string, initiators may be blank (for all initiators) or a comma separated list of integers as defined in <a href="https://www.zaproxy.org/docs/constants/">Request Initiator Constants</a>  
         This component is optional and therefore the API will only work if it is installed
@@ -47,6 +47,8 @@ class replacer(object):
             params['initiators'] = initiators
         if url is not None:
             params['url'] = url
+        if method is not None:
+            params['method'] = method
         return six.next(six.itervalues(self.zap._request(self.zap.base + 'replacer/action/addRule/', params)))
 
     def remove_rule(self, description, apikey=''):


### PR DESCRIPTION
I saw the option to specify a `method` when adding Replacer rules was recently added to the API, but I wasn't able to use it with the Python library because it hasn't been exposed yet, so thought I would create a PR myself. Hope that's okay!

Please let me know if there is anything more you need from me or that is missing.