### PR TITLE
Do not unwrap `alert_counts_by_risk`'s response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Added support for 'method' parameter on Replacer 'add_rule'
 
+### Fixed
+- Return the whole response from `alert.alert_counts_by_risk` (Issue 9314).
+
 ## [0.5.0] - 2025-12-15
 ### Added
 - Add the APIs of the following add-ons:

--- a/src/zapv2/alert.py
+++ b/src/zapv2/alert.py
@@ -92,7 +92,7 @@ class alert(object):
             params['url'] = url
         if recurse is not None:
             params['recurse'] = recurse
-        return six.next(six.itervalues(self.zap._request(self.zap.base + 'alert/view/alertCountsByRisk/', params)))
+        return (self.zap._request(self.zap.base + 'alert/view/alertCountsByRisk/', params))
 
     def delete_all_alerts(self, apikey=''):
         """


### PR DESCRIPTION
Return the response directly as it's not wrapped in an object.

Close zaproxy/zaproxy#9314.